### PR TITLE
[Feat/#48] 텍스트 편집기 빈(Empty) 상태 화면 구현

### DIFF
--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorIntent.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorIntent.kt
@@ -36,7 +36,7 @@ sealed class CardEditorIntent {
     data object ResetTransform: CardEditorIntent()
 
     /* 텍스트 편집 */
-    data object RequestDefaultText: CardEditorIntent()
+    data object MissingTextSelection: CardEditorIntent()
     data object AddText: CardEditorIntent()
     data class DeleteText(val textId: Long): CardEditorIntent()
     data class SelectText(val textId: Long): CardEditorIntent()

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
@@ -107,7 +107,7 @@ class CardEditorViewModel @Inject constructor(
             is CardEditorIntent.ResetTransform -> handleResetTransform()
 
             /* 텍스트 편집 */
-            is CardEditorIntent.RequestDefaultText -> handleRequestDefaultText()
+            is CardEditorIntent.MissingTextSelection -> handleMissingTextSelection()
             is CardEditorIntent.AddText -> handleAddText()
             is CardEditorIntent.DeleteText -> handleDeleteText(intent.textId)
             is CardEditorIntent.SelectText -> handleSelectText(intent.textId)
@@ -397,24 +397,11 @@ class CardEditorViewModel @Inject constructor(
     }
 
     /* 텍스트 편집 */
-    private fun handleRequestDefaultText() {
+    private fun handleMissingTextSelection() {
         if (_cardEditorState.value.tempTextList.isNotEmpty() && _cardEditorState.value.selectedTextTempId == null) {
             _cardEditorState.update { it.copy(selectedTextTempId = it.tempTextList.first().tempId) }
             return
         }
-
-        val newTextElement = TempTextElement()
-        _cardEditorState.update {
-            it.copy(
-                tempTextList = listOf(newTextElement),
-                selectedTextTempId = newTextElement.tempId
-            )
-        }
-
-        unityBridge.createText(
-            tempId = newTextElement.tempId,
-            textElement = newTextElement.textElement
-        )
     }
 
     private fun handleAddText() {

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
@@ -433,6 +433,8 @@ class CardEditorViewModel @Inject constructor(
         }
 
         selectedText.textElement.elementId?.let { _deletedTextElementIds.add(it) }
+
+        unityBridge.deleteObject(selectedText.tempId)
     }
 
     private fun handleSelectText(textId: Long) {

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/CardEditorBottomScreen.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/CardEditorBottomScreen.kt
@@ -55,24 +55,21 @@ fun CardEditorBottomScreen(cardId: Long, viewModel: CardEditorViewModel = hiltVi
 
         PanelType.TEXT_EDITOR -> {
             val tempText = state.selectedText
-            if(state.tempTextList.isEmpty() || tempText == null) {
-                LaunchedEffect(state.panelType, state.tempTextList, state.selectedText) {
-                    viewModel.onIntent(CardEditorIntent.RequestDefaultText)
-                }
-            } else {
-                TextEditorPanel(
-                    textElement = tempText.textElement,
-                    onTextChange = { viewModel.onIntent(CardEditorIntent.ChangeTextContent(it)) },
-                    onAlignmentSelected = { viewModel.onIntent(CardEditorIntent.SelectAlignment(it)) },
-                    onColorSelected = { viewModel.onIntent(CardEditorIntent.SelectColor(it)) },
-                    onFontSizeChange = { viewModel.onIntent(CardEditorIntent.ChangeFontSize(it)) },
-                    onFontSelected = { viewModel.onIntent(CardEditorIntent.SelectFont(it)) },
-                    onPositionChange = { viewModel.onIntent(CardEditorIntent.MoveText(it)) },
-                    onCameraReset = { viewModel.onIntent(CardEditorIntent.ResetCamera) },
-                    onApply = { viewModel.onIntent(CardEditorIntent.ApplyText(cardId)) },
-                    onBack = { viewModel.onIntent(CardEditorIntent.ChangeDialogState(DialogState.UNSAVED_TEXT_CHANGES)) }
-                )
+            if(tempText == null) {
+                viewModel.onIntent(CardEditorIntent.MissingTextSelection)
             }
+            TextEditorPanel(
+                textElement = tempText?.textElement,
+                onTextChange = { viewModel.onIntent(CardEditorIntent.ChangeTextContent(it)) },
+                onAlignmentSelected = { viewModel.onIntent(CardEditorIntent.SelectAlignment(it)) },
+                onColorSelected = { viewModel.onIntent(CardEditorIntent.SelectColor(it)) },
+                onFontSizeChange = { viewModel.onIntent(CardEditorIntent.ChangeFontSize(it)) },
+                onFontSelected = { viewModel.onIntent(CardEditorIntent.SelectFont(it)) },
+                onPositionChange = { viewModel.onIntent(CardEditorIntent.MoveText(it)) },
+                onCameraReset = { viewModel.onIntent(CardEditorIntent.ResetCamera) },
+                onApply = { viewModel.onIntent(CardEditorIntent.ApplyText(cardId)) },
+                onBack = { viewModel.onIntent(CardEditorIntent.ChangeDialogState(DialogState.UNSAVED_TEXT_CHANGES)) }
+            )
         }
     }
 

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TextEditorPanel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TextEditorPanel.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -64,7 +65,7 @@ enum class TextEditorTab(val resId: Int) {
 
 @Composable
 fun TextEditorPanel(
-    textElement: TextElement = TextElement(),
+    textElement: TextElement? = null,
     onTextChange: (String) -> Unit = {},
     onColorSelected: (ColorOption) -> Unit = {},
     onAlignmentSelected: (TextAlignmentOption) -> Unit = {},
@@ -95,7 +96,7 @@ fun TextEditorPanel(
 
 @Composable
 private fun EditorTabContent(
-    textElement: TextElement,
+    textElement: TextElement?,
     selectedTab: TextEditorTab,
     onTextChange: (String) -> Unit,
     onTabSelected: (TextEditorTab) -> Unit,
@@ -110,17 +111,25 @@ private fun EditorTabContent(
 ) {
     Column(
         modifier = Modifier
+            .fillMaxHeight()
             .background(White)
             .padding(horizontal = 16.dp)
             .padding(top = 12.dp)
     ) {
         // 텍스트 입력, 적용, 뒤로 가기
         EditorHeader(
-            text = textElement.attributes.content,
+            text = textElement?.attributes?.content ?: "",
+            hasText = textElement != null,
             onBack = onBack,
             onApply = onApply,
             onTextChange = onTextChange
         )
+
+        if (textElement == null) {
+            EmptyEditorContent()
+            return@Column
+        }
+
         Spacer(Modifier.height(18.dp))
 
         // "Style", "font", "Position" 탭
@@ -158,6 +167,7 @@ private fun EditorTabContent(
 @Composable
 private fun EditorHeader(
     text: String,
+    hasText: Boolean,
     onBack: () -> Unit,
     onApply: () -> Unit,
     onTextChange: (String) -> Unit,
@@ -182,6 +192,9 @@ private fun EditorHeader(
                 )
             }
         }
+
+        if(!hasText) return@Row
+
         BasicTextField(
             modifier = Modifier
                 .weight(1f)
@@ -377,6 +390,22 @@ private fun PositionOptions(onPositionChange: (Direction) -> Unit, onCameraReset
             onClick = onPositionChange,
             onCameraReset = onCameraReset
         )
+    }
+}
+
+@Composable
+private fun EmptyEditorContent() {
+    Column (
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = stringResource(R.string.editor_content_empty_text),
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.weight(2f))
     }
 }
 

--- a/feature/card/src/main/res/values/strings.xml
+++ b/feature/card/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="editor_button_back">Back</string>
     <string name="editor_placeholder_text">New Text</string>
     <string name="editor_cd_align_icon">Align %s</string>
+    <string name="editor_content_empty_text">No text added.\nTap \'+\' to add your first text!</string>
 
     <string name="editor_dialog_button_delete">Delete</string>
     <string name="editor_dialog_button_save">Yes</string>


### PR DESCRIPTION
## Related Issue
- Close: #48 

## Screenshot
<img width="20%" src="https://github.com/user-attachments/assets/c2ed54b3-fde6-49b9-b1bf-c396163bbb27"/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 카드 편집 시 텍스트가 없는 상태에서 사용자를 위한 안내 메시지가 표시됩니다.
  * 텍스트 편집 화면의 빈 상태 처리가 개선되었습니다.
  * 텍스트 삭제 시 리소스 정리 동작이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->