### PR TITLE
[Feat/#54] 에셋 Z축 이동 추가 

### DIFF
--- a/core/data/src/main/java/com/itschristmas/data/bridgeimpl/UnityBridgeImpl.kt
+++ b/core/data/src/main/java/com/itschristmas/data/bridgeimpl/UnityBridgeImpl.kt
@@ -41,7 +41,7 @@ class UnityBridgeImpl @Inject constructor(): UnityBridge {
                         position = Vector3Dto(
                             x = it.posX,
                             y = it.posY,
-                            z = 0f
+                            z = it.posZ
                         ),
                         textContent = it.attributes.content,
                         fontFamilyName = it.attributes.fontFamily.key,

--- a/core/data/src/main/java/com/itschristmas/data/repositoryImpl/CardElementRepositoryImpl.kt
+++ b/core/data/src/main/java/com/itschristmas/data/repositoryImpl/CardElementRepositoryImpl.kt
@@ -59,12 +59,12 @@ class CardElementRepositoryImpl @Inject constructor(
             cardElementDao.getTextElementsByCardId(cardId).map { it.toDomain() }
         }
 
-    override suspend fun updateElementTransform(elementId: Long, posX: Float, posY: Float, scale: Int): Result<Int> =
+    override suspend fun updateElementTransform(elementId: Long, posX: Float, posY: Float, posZ: Float, scale: Int): Result<Int> =
         ioCatching {
-            cardElementDao.updateElementTransform(elementId, posX, posY, scale)
+            cardElementDao.updateElementTransform(elementId, posX, posY, posZ, scale)
         }
 
-    override suspend fun updateTextElement(elementId: Long, textAttributes: TextAttributes, posX: Float, posY: Float): Result<Int> =
+    override suspend fun updateTextElement(elementId: Long, textAttributes: TextAttributes, posX: Float, posY: Float, posZ: Float): Result<Int> =
         ioCatching {
             cardElementDao.updateTextElement(
                 elementId = elementId,
@@ -74,7 +74,8 @@ class CardElementRepositoryImpl @Inject constructor(
                 fontSize = textAttributes.fontSize,
                 fontFamily = textAttributes.fontFamily.name,
                 posX = posX,
-                posY = posY
+                posY = posY,
+                posZ = posZ
             )
         }
 }

--- a/core/data/src/main/java/com/itschristmas/data/usecaseImpl/GetTextElementsUseCaseImpl.kt
+++ b/core/data/src/main/java/com/itschristmas/data/usecaseImpl/GetTextElementsUseCaseImpl.kt
@@ -21,7 +21,8 @@ class GetTextElementsUseCaseImpl @Inject constructor(
                             elementId = element.elementId,
                             attributes = attr,
                             posX = element.posX,
-                            posY = element.posY
+                            posY = element.posY,
+                            posZ = element.posZ
                         )
                     }
                 }

--- a/core/data/src/main/java/com/itschristmas/data/usecaseImpl/SaveTextElementsUseCaseImpl.kt
+++ b/core/data/src/main/java/com/itschristmas/data/usecaseImpl/SaveTextElementsUseCaseImpl.kt
@@ -36,7 +36,8 @@ class SaveTextElementsUseCaseImpl @Inject constructor(
                             elementId = id,
                             textAttributes = text.attributes,
                             posX = text.posX,
-                            posY = text.posY
+                            posY = text.posY,
+                            posZ = text.posZ
                         ).onSuccess {
                             updated += text
                         }.onFailure {
@@ -51,6 +52,7 @@ class SaveTextElementsUseCaseImpl @Inject constructor(
                                 elementType = ElementType.TEXT,
                                 posX = text.posX,
                                 posY = text.posY,
+                                posZ = text.posZ,
                                 textAttributes = text.attributes
                             )
                         ).onSuccess { id ->

--- a/core/database/src/main/java/com/itschristmas/database/dao/CardElementDao.kt
+++ b/core/database/src/main/java/com/itschristmas/database/dao/CardElementDao.kt
@@ -41,13 +41,13 @@ interface CardElementDao {
     @Query("SELECT * FROM card_elements WHERE cardId = :cardId and elementType = 'TEXT'")
     suspend fun getTextElementsByCardId(cardId: Long): List<CardElementEntity>
 
-    @Query("UPDATE card_elements SET posX = :posX, posY = :posY, scale = :scale WHERE elementId = :elementId")
-    suspend fun updateElementTransform(elementId: Long, posX: Float, posY: Float, scale: Int): Int
+    @Query("UPDATE card_elements SET posX = :posX, posY = :posY, posZ = :posZ, scale = :scale WHERE elementId = :elementId")
+    suspend fun updateElementTransform(elementId: Long, posX: Float, posY: Float, posZ: Float, scale: Int): Int
 
     @Query("""
         UPDATE card_elements 
-        SET textContent = :textContent, textAlign = :textAlign, textColor = :textColor, fontSize = :fontSize, fontFamily = :fontFamily, posX = :posX, posY = :posY 
+        SET textContent = :textContent, textAlign = :textAlign, textColor = :textColor, fontSize = :fontSize, fontFamily = :fontFamily, posX = :posX, posY = :posY, posZ = :posZ
         WHERE elementId = :elementId
         """)
-    suspend fun updateTextElement(elementId: Long, textContent: String, textAlign: String, textColor: String, fontSize: Float, fontFamily: String, posX: Float, posY: Float): Int
+    suspend fun updateTextElement(elementId: Long, textContent: String, textAlign: String, textColor: String, fontSize: Float, fontFamily: String, posX: Float, posY: Float, posZ: Float): Int
 }

--- a/core/domain/src/main/java/com/itschristmas/domain/bridge/UnityBridge.kt
+++ b/core/domain/src/main/java/com/itschristmas/domain/bridge/UnityBridge.kt
@@ -30,7 +30,7 @@ interface UnityBridge {
         elementId: Long,
         posX: Float,
         posY: Float,
-        posZ: Float = 0f,
+        posZ: Float
     )
 
     fun updateScale(elementId: Long, scale: Int)

--- a/core/domain/src/main/java/com/itschristmas/domain/model/CardElement.kt
+++ b/core/domain/src/main/java/com/itschristmas/domain/model/CardElement.kt
@@ -11,9 +11,9 @@ data class CardElement(
     val elementType: ElementType,
 
     // Transform
-    val posX: Float = Random.nextDouble(-2.0, 2.0).toFloat(),
-    val posY: Float = Random.nextDouble(-2.0, 2.0).toFloat(),
-    val posZ: Float = 0f,
+    val posX: Float = Random.nextInt(-20, 21) / 10f,
+    val posY: Float = Random.nextInt(-20, 21) / 10f,
+    val posZ: Float = Random.nextInt(-10, 11) / 10f,
 
     val rotX: Int = 0,
     val rotY: Int = 0,

--- a/core/domain/src/main/java/com/itschristmas/domain/model/TextElement.kt
+++ b/core/domain/src/main/java/com/itschristmas/domain/model/TextElement.kt
@@ -11,7 +11,7 @@ data class TextElement(
         fontSize = 14f,
         fontFamily = FontOption.PlaywriteUsTradGuides,
     ),
-    val posX: Float = Random.nextDouble(-2.0, 2.0).toFloat(),
-    val posY: Float = Random.nextDouble(-2.0, 2.0).toFloat(),
-    val posZ: Float = 0f
+    val posX: Float = Random.nextInt(-20, 21) / 10f,
+    val posY: Float = Random.nextInt(-20, 21) / 10f,
+    val posZ: Float = Random.nextInt(-10, 11) / 10f
 )

--- a/core/domain/src/main/java/com/itschristmas/domain/repository/CardElementRepository.kt
+++ b/core/domain/src/main/java/com/itschristmas/domain/repository/CardElementRepository.kt
@@ -21,7 +21,7 @@ interface CardElementRepository {
 
     suspend fun getTextElementsByCardId(cardId: Long): Result<List<CardElement>>
 
-    suspend fun updateElementTransform(elementId: Long, posX: Float, posY: Float, scale: Int): Result<Int>
+    suspend fun updateElementTransform(elementId: Long, posX: Float, posY: Float, posZ: Float, scale: Int): Result<Int>
 
-    suspend fun updateTextElement(elementId: Long, textAttributes: TextAttributes, posX: Float, posY: Float): Result<Int>
+    suspend fun updateTextElement(elementId: Long, textAttributes: TextAttributes, posX: Float, posY: Float, posZ: Float): Result<Int>
 }

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
@@ -305,7 +305,8 @@ class CardEditorViewModel @Inject constructor(
                     elementId = element.elementId,
                     attributes = element.attributes,
                     posX = element.posX,
-                    posY = element.posY
+                    posY = element.posY,
+                    posZ = element.posZ
                 )
             )
         }.asReversed()
@@ -336,14 +337,15 @@ class CardEditorViewModel @Inject constructor(
         val tempState = _cardEditorState.value.tempTransform ?: return
         val updatedPosX = tempState.posX + direction.dx
         val updatedPosY = tempState.posY + direction.dy
+        val updatedPosZ = tempState.posZ + direction.dz
 
         _cardEditorState.update {
             it.copy(tempTransform =
-                tempState.copy(posX = updatedPosX, posY = updatedPosY)
+                tempState.copy(posX = updatedPosX, posY = updatedPosY, posZ = updatedPosZ)
             )
         }
 
-        unityBridge.updatePosition(tempState.elementId, updatedPosX, updatedPosY)
+        unityBridge.updatePosition(tempState.elementId, updatedPosX, updatedPosY, updatedPosZ)
     }
 
     private fun handleChangeScale(newScale: Int) {
@@ -390,6 +392,7 @@ class CardEditorViewModel @Inject constructor(
                 tempState.copy(
                     posX = initialState?.posX ?: 0f,
                     posY = initialState?.posY ?: 0f,
+                    posZ = initialState?.posZ ?: 0f,
                     scale = initialState?.scale ?: 1
                 )
             )
@@ -481,11 +484,13 @@ class CardEditorViewModel @Inject constructor(
                 if(item.tempId == textId) {
                     val newPosX = item.textElement.posX + direction.dx
                     val newPosY = item.textElement.posY + direction.dy
-                    unityBridge.updatePosition(textId, newPosX, newPosY)
+                    val newPosZ = item.textElement.posZ + direction.dz
+                    unityBridge.updatePosition(textId, newPosX, newPosY, newPosZ)
                     item.copy(
                         textElement = item.textElement.copy(
                             posX = newPosX,
-                            posY = newPosY
+                            posY = newPosY,
+                            posZ = newPosZ
                         )
                     )
                 } else item
@@ -544,6 +549,7 @@ class CardEditorViewModel @Inject constructor(
                 elementId = tempState.elementId,
                 posX = tempState.posX,
                 posY = tempState.posY,
+                posZ = tempState.posZ,
                 scale = tempState.scale
             ).onSuccess {
                 _cardEditorState.update {
@@ -552,6 +558,7 @@ class CardEditorViewModel @Inject constructor(
                             cardElement = initialState.cardElement.copy(
                                 posX = tempState.posX,
                                 posY = tempState.posY,
+                                posZ = tempState.posZ,
                                 scale = tempState.scale
                             )
                         )
@@ -619,9 +626,10 @@ class CardEditorViewModel @Inject constructor(
 
         val initialPosX = initialState.posX
         val initialPosY = initialState.posY
+        val initialPosZ = initialState.posZ
         val initialScale = initialState.scale
 
-        unityBridge.updatePosition(initialState.elementId, initialPosX, initialPosY)
+        unityBridge.updatePosition(initialState.elementId, initialPosX, initialPosY, initialPosZ)
         unityBridge.updateScale(initialState.elementId, initialScale)
     }
 }

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/model/Direction.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/model/Direction.kt
@@ -1,8 +1,10 @@
 package com.itschristmas.card.cardeditor.model
 
-enum class Direction(val dx: Int, val dy: Int) {
-    UP(0, 1),
-    DOWN(0, -1),
-    LEFT(-1, 0),
-    RIGHT(1, 0)
+enum class Direction(val dx: Float, val dy: Float, val dz: Float) {
+    UP(0f, .1f, 0f),
+    DOWN(0f, -.1f, 0f),
+    LEFT(-.1f, 0f, 0f),
+    RIGHT(.1f, 0f, 0f),
+    FORWARD(0f, 0f, -.1f),
+    BACKWARD(0f, 0f, .1f)
 }

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/CardEditorBottomScreen.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/CardEditorBottomScreen.kt
@@ -48,8 +48,7 @@ fun CardEditorBottomScreen(cardId: Long, viewModel: CardEditorViewModel = hiltVi
                 onApply = { viewModel.onIntent(CardEditorIntent.ApplyTransform) },
                 onDirectionalClick = { direction ->
                     viewModel.onIntent(CardEditorIntent.MoveObject(direction))
-                },
-                onCameraReset = { viewModel.onIntent(CardEditorIntent.ResetCamera) }
+                }
             )
         }
 
@@ -66,7 +65,6 @@ fun CardEditorBottomScreen(cardId: Long, viewModel: CardEditorViewModel = hiltVi
                 onFontSizeChange = { viewModel.onIntent(CardEditorIntent.ChangeFontSize(it)) },
                 onFontSelected = { viewModel.onIntent(CardEditorIntent.SelectFont(it)) },
                 onPositionChange = { viewModel.onIntent(CardEditorIntent.MoveText(it)) },
-                onCameraReset = { viewModel.onIntent(CardEditorIntent.ResetCamera) },
                 onApply = { viewModel.onIntent(CardEditorIntent.ApplyText(cardId)) },
                 onBack = { viewModel.onIntent(CardEditorIntent.ChangeDialogState(DialogState.UNSAVED_TEXT_CHANGES)) }
             )

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/common/DirectionalController.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/common/DirectionalController.kt
@@ -7,24 +7,29 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.itschristmas.card.cardeditor.model.Direction
 import com.itschristmas.designsystem.theme.ItsChristmasTheme
+
+enum class Axis(val label: String) {
+    XY("x/y"), YZ("y/z")
+}
 
 /**
  * 상하좌우 방향키 컨트롤러
@@ -33,8 +38,9 @@ import com.itschristmas.designsystem.theme.ItsChristmasTheme
 fun DirectionalController(
     modifier: Modifier = Modifier,
     onClick: (Direction) -> Unit,
-    onCameraReset: () -> Unit
 ) {
+    var axis by remember { mutableStateOf(Axis.XY) }
+
     Box(
         modifier = modifier
             .aspectRatio(1f),
@@ -46,30 +52,32 @@ fun DirectionalController(
                 .fillMaxSize(0.2f)
                 .clip(CircleShape)
                 .background(Color.LightGray.copy(alpha = 0.5f))
-                .clickable { onCameraReset() }
-        )
+                .clickable { axis = if(axis == Axis.XY) Axis.YZ else Axis.XY },
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = axis.label,
+                style = MaterialTheme.typography.labelSmall
+            )
+        }
 
         // 방향 버튼들
         ControlButton(
-            icon = Icons.Default.KeyboardArrowUp,
             direction = Direction.UP,
             onClick = onClick,
             modifier = Modifier.align(Alignment.TopCenter)
         )
         ControlButton(
-            icon = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-            direction = Direction.LEFT,
+            direction = if(axis == Axis.XY) Direction.LEFT else Direction.FORWARD,
             onClick = onClick,
             modifier = Modifier.align(Alignment.CenterStart)
         )
         ControlButton(
-            icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-            direction = Direction.RIGHT,
+            direction = if(axis == Axis.XY) Direction.RIGHT else Direction.BACKWARD,
             onClick = onClick,
             modifier = Modifier.align(Alignment.CenterEnd)
         )
         ControlButton(
-            icon = Icons.Default.KeyboardArrowDown,
             direction = Direction.DOWN,
             onClick = onClick,
             modifier = Modifier.align(Alignment.BottomCenter)
@@ -83,22 +91,20 @@ fun DirectionalController(
 @Composable
 private fun ControlButton(
     modifier: Modifier = Modifier,
-    icon: ImageVector,
     direction: Direction,
     onClick: (Direction) -> Unit
 ) {
     IconButton(
         onClick = { onClick(direction) },
         modifier = modifier
+            .semantics { contentDescription = "$direction Button" }
             .fillMaxSize(0.3f)
             .shadow(elevation = 3.dp, shape = CircleShape)
-            .background(Color.White, CircleShape)
+            .background(Color.White, CircleShape),
     ) {
-        Icon(
-            modifier = Modifier.fillMaxSize(0.64f),
-            imageVector = icon,
-            contentDescription = "$direction Button",
-            tint = Color.Black
+        Text(
+            text = direction.name[0].toString(),
+            style = MaterialTheme.typography.titleLarge
         )
     }
 }
@@ -110,7 +116,6 @@ fun DirectionControllerPreview() {
         DirectionalController(
             modifier = Modifier.size(220.dp),
             onClick = {},
-            onCameraReset = {}
         )
     }
 }

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TextEditorPanel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TextEditorPanel.kt
@@ -72,7 +72,6 @@ fun TextEditorPanel(
     onFontSizeChange: (Float) -> Unit = {},
     onFontSelected: (FontOption) -> Unit = {},
     onPositionChange: (Direction) -> Unit = { },
-    onCameraReset: () -> Unit = {},
     onApply: () -> Unit = {},
     onBack: () -> Unit = {}
 ) {
@@ -88,7 +87,6 @@ fun TextEditorPanel(
         onFontSizeChange = onFontSizeChange,
         onFontSelected = onFontSelected,
         onPositionChange = onPositionChange,
-        onCameraReset = onCameraReset,
         onApply = onApply,
         onBack = onBack
     )
@@ -105,7 +103,6 @@ private fun EditorTabContent(
     onFontSizeChange: (Float) -> Unit,
     onFontSelected: (FontOption) -> Unit,
     onPositionChange: (Direction) -> Unit,
-    onCameraReset: () -> Unit,
     onApply: () -> Unit,
     onBack: () -> Unit
 ) {
@@ -155,10 +152,7 @@ private fun EditorTabContent(
                 FontOptions(selectedFont = textElement.attributes.fontFamily, onFontSelected = onFontSelected)
             }
             TextEditorTab.POSITION -> {
-                PositionOptions(
-                    onPositionChange = onPositionChange,
-                    onCameraReset = onCameraReset
-                )
+                PositionOptions(onPositionChange = onPositionChange)
             }
         }
     }
@@ -379,7 +373,7 @@ private fun FontChip(font: FontOption, isSelected: Boolean, fontFamily: FontFami
 }
 
 @Composable
-private fun PositionOptions(onPositionChange: (Direction) -> Unit, onCameraReset: () -> Unit) {
+private fun PositionOptions(onPositionChange: (Direction) -> Unit) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -388,7 +382,6 @@ private fun PositionOptions(onPositionChange: (Direction) -> Unit, onCameraReset
     ) {
         DirectionalController(
             onClick = onPositionChange,
-            onCameraReset = onCameraReset
         )
     }
 }

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TransformControlPanel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TransformControlPanel.kt
@@ -33,7 +33,6 @@ fun TransformControlPanel(
     scale: Int = 1,
     onScaleChange: (Int) -> Unit = {},
     onDirectionalClick: (Direction) -> Unit = {},
-    onCameraReset: () -> Unit = {},
     onCancel: () -> Unit = {},
     onApply: () -> Unit = {},
 ) {
@@ -55,7 +54,7 @@ fun TransformControlPanel(
             horizontalArrangement = Arrangement.spacedBy(40.dp) // 방향키와 수량 조절기 사이 간격
         ) {
             // 2-1. 방향키 컨트롤러
-            DirectionalController(onClick = onDirectionalClick, onCameraReset = onCameraReset)
+            DirectionalController(onClick = onDirectionalClick)
 
             // 2-2. Scale 조절기
             ScaleController(


### PR DESCRIPTION
## Related Issue
- Close: #54 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 3D 위치 지정 시스템 추가: 깊이 좌표(Z축) 지원으로 요소 배치 향상
  * 방향 컨트롤에 축 토글 기능 추가: X/Y 및 Y/Z 평면 간 전환 가능
  * 전진/후진 이동 옵션 추가로 3D 공간 탐색 확대

* **개선 사항**
  * 방향 컨트롤 UI 개선: 아이콘 기반에서 텍스트 기반 표시로 변경
  * 위치 제어 인터페이스 단순화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->