### PR TITLE
[Feat/#61] 카드 리스트 최신 편집 순 정렬

### DIFF
--- a/core/data/src/main/java/com/itschristmas/data/repositoryImpl/CardElementRepositoryImpl.kt
+++ b/core/data/src/main/java/com/itschristmas/data/repositoryImpl/CardElementRepositoryImpl.kt
@@ -1,9 +1,12 @@
 package com.itschristmas.data.repositoryImpl
 
+import androidx.room.withTransaction
 import com.itschristmas.domain.model.CardElementWithAssetKeys
 import com.itschristmas.data.mapper.toDomain
 import com.itschristmas.data.mapper.toEntity
 import com.itschristmas.data.repositoryImpl.common.ioCatching
+import com.itschristmas.database.AppDatabase
+import com.itschristmas.database.dao.CardDao
 import com.itschristmas.database.dao.CardElementDao
 import com.itschristmas.domain.model.CardElement
 import com.itschristmas.domain.model.TextAttributes
@@ -16,31 +19,41 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class CardElementRepositoryImpl @Inject constructor(
+    private val db: AppDatabase,
+    private val cardDao: CardDao,
     private val cardElementDao: CardElementDao
 ): CardElementRepository {
-    override suspend fun insertCardElements(cardElements: List<CardElement>): Result<List<Long>> =
-        ioCatching {
-            cardElementDao.insertAll(cardElements.map { it.toEntity() })
-        }
 
     override suspend fun insertCardElement(cardElement: CardElement): Result<Long> =
         ioCatching {
-            cardElementDao.insertElement(cardElement.toEntity())
+            db.withTransaction {
+                cardDao.refreshUpdatedAt(cardElement.cardId)
+                cardElementDao.insertElement(cardElement.toEntity())
+            }
         }
 
     override suspend fun deleteCardElementsByCardId(cardId: Long): Result<Int> =
         ioCatching {
-            cardElementDao.deleteByCardId(cardId)
+            db.withTransaction {
+                cardDao.refreshUpdatedAt(cardId)
+                cardElementDao.deleteByCardId(cardId)
+            }
         }
 
-    override suspend fun deleteCardElementById(elementId: Long): Result<Int> =
+    override suspend fun deleteCardElementById(cardId: Long, elementId: Long): Result<Int> =
         ioCatching {
-            cardElementDao.deleteElementById(elementId)
+            db.withTransaction {
+                cardDao.refreshUpdatedAt(cardId)
+                cardElementDao.deleteElementById(elementId)
+            }
         }
 
-    override suspend fun deleteCardElementsByIds(elementIds: List<Long>): Result<Int> =
+    override suspend fun deleteCardElementsByIds(cardId: Long, elementIds: List<Long>): Result<Int> =
         ioCatching {
-            cardElementDao.deleteElementsByIds(elementIds)
+            db.withTransaction {
+                cardDao.refreshUpdatedAt(cardId)
+                cardElementDao.deleteElementsByIds(elementIds)
+            }
         }
 
     override fun getObjectElementsWithAssetKeysByCardId(cardId: Long): Flow<Result<List<CardElementWithAssetKeys>>> {
@@ -59,23 +72,29 @@ class CardElementRepositoryImpl @Inject constructor(
             cardElementDao.getTextElementsByCardId(cardId).map { it.toDomain() }
         }
 
-    override suspend fun updateElementTransform(elementId: Long, posX: Float, posY: Float, posZ: Float, scale: Int): Result<Int> =
+    override suspend fun updateElementTransform(cardId: Long, elementId: Long, posX: Float, posY: Float, posZ: Float, scale: Int): Result<Int> =
         ioCatching {
-            cardElementDao.updateElementTransform(elementId, posX, posY, posZ, scale)
+            db.withTransaction {
+                cardDao.refreshUpdatedAt(cardId)
+                cardElementDao.updateElementTransform(elementId, posX, posY, posZ, scale)
+            }
         }
 
-    override suspend fun updateTextElement(elementId: Long, textAttributes: TextAttributes, posX: Float, posY: Float, posZ: Float): Result<Int> =
+    override suspend fun updateTextElement(cardId: Long, elementId: Long, textAttributes: TextAttributes, posX: Float, posY: Float, posZ: Float): Result<Int> =
         ioCatching {
-            cardElementDao.updateTextElement(
-                elementId = elementId,
-                textContent = textAttributes.content,
-                textAlign = textAttributes.alignment.name,
-                textColor = textAttributes.textColor.name,
-                fontSize = textAttributes.fontSize,
-                fontFamily = textAttributes.fontFamily.name,
-                posX = posX,
-                posY = posY,
-                posZ = posZ
-            )
+            db.withTransaction {
+                cardDao.refreshUpdatedAt(cardId)
+                cardElementDao.updateTextElement(
+                    elementId = elementId,
+                    textContent = textAttributes.content,
+                    textAlign = textAttributes.alignment.name,
+                    textColor = textAttributes.textColor.name,
+                    fontSize = textAttributes.fontSize,
+                    fontFamily = textAttributes.fontFamily.name,
+                    posX = posX,
+                    posY = posY,
+                    posZ = posZ
+                )
+            }
         }
 }

--- a/core/data/src/main/java/com/itschristmas/data/usecaseImpl/SaveTextElementsUseCaseImpl.kt
+++ b/core/data/src/main/java/com/itschristmas/data/usecaseImpl/SaveTextElementsUseCaseImpl.kt
@@ -33,6 +33,7 @@ class SaveTextElementsUseCaseImpl @Inject constructor(
                 nonEmptyTextList.forEach { text ->
                     text.elementId?.let { id ->
                         cardElementRepository.updateTextElement(
+                            cardId = params.cardId,
                             elementId = id,
                             textAttributes = text.attributes,
                             posX = text.posX,
@@ -68,7 +69,7 @@ class SaveTextElementsUseCaseImpl @Inject constructor(
                     addAll(emptyTextList.mapNotNull { it.elementId })
                 }.toList()
 
-                cardElementRepository.deleteCardElementsByIds(toDelete)
+                cardElementRepository.deleteCardElementsByIds(params.cardId, toDelete)
                     .onFailure {
                         failedDeleteIds.addAll(toDelete)
                         Log.e(TAG, "deleteCardElementsByIds failed: $it")

--- a/core/database/src/main/java/com/itschristmas/database/dao/CardDao.kt
+++ b/core/database/src/main/java/com/itschristmas/database/dao/CardDao.kt
@@ -28,8 +28,11 @@ interface CardDao {
     )
     suspend fun getGlbAndBgFirebaseKey(cardId: Long): GlbAndBgFirebaseDto
 
-    @Query("UPDATE cards SET backgroundAssetId = :backgroundAssetId WHERE cardId = :cardId")
-    suspend fun updateBackgroundAssetId(cardId: Long, backgroundAssetId: Long): Int
+    @Query("UPDATE cards SET updatedAt = :updatedAt WHERE cardId = :cardId")
+    suspend fun refreshUpdatedAt(cardId: Long, updatedAt: Long = System.currentTimeMillis()): Int
+
+    @Query("UPDATE cards SET backgroundAssetId = :backgroundAssetId, updatedAt = :updatedAt WHERE cardId = :cardId")
+    suspend fun updateBackgroundAssetId(cardId: Long, backgroundAssetId: Long, updatedAt: Long = System.currentTimeMillis()): Int
 
     @Query("UPDATE cards SET glbFileName = :glbFileName, glbToken = :glbToken WHERE cardId = :cardId")
     suspend fun updateGlb(cardId: Long, glbFileName: String, glbToken: String): Int

--- a/core/database/src/main/java/com/itschristmas/database/dao/CardDao.kt
+++ b/core/database/src/main/java/com/itschristmas/database/dao/CardDao.kt
@@ -12,7 +12,7 @@ interface CardDao {
     @Insert
     suspend fun insertCard(card: CardEntity): Long
 
-    @Query("SELECT * FROM cards")
+    @Query("SELECT * FROM cards ORDER BY updatedAt DESC")
     suspend fun getAllCards(): List<CardEntity>
 
     @Query("SELECT * FROM cards WHERE cardId = :cardId")
@@ -34,6 +34,6 @@ interface CardDao {
     @Query("UPDATE cards SET backgroundAssetId = :backgroundAssetId, updatedAt = :updatedAt WHERE cardId = :cardId")
     suspend fun updateBackgroundAssetId(cardId: Long, backgroundAssetId: Long, updatedAt: Long = System.currentTimeMillis()): Int
 
-    @Query("UPDATE cards SET glbFileName = :glbFileName, glbToken = :glbToken WHERE cardId = :cardId")
-    suspend fun updateGlb(cardId: Long, glbFileName: String, glbToken: String): Int
+    @Query("UPDATE cards SET glbFileName = :glbFileName, glbToken = :glbToken, updatedAt = :updatedAt WHERE cardId = :cardId")
+    suspend fun updateGlb(cardId: Long, glbFileName: String, glbToken: String, updatedAt: Long = System.currentTimeMillis()): Int
 }

--- a/core/database/src/main/java/com/itschristmas/database/dao/CardElementDao.kt
+++ b/core/database/src/main/java/com/itschristmas/database/dao/CardElementDao.kt
@@ -12,9 +12,6 @@ import kotlinx.coroutines.flow.Flow
 interface CardElementDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertAll(cardElements: List<CardElementEntity>): List<Long>
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertElement(cardElement: CardElementEntity): Long
 
     @Query("DELETE FROM card_elements")

--- a/core/domain/src/main/java/com/itschristmas/domain/repository/CardElementRepository.kt
+++ b/core/domain/src/main/java/com/itschristmas/domain/repository/CardElementRepository.kt
@@ -7,8 +7,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface CardElementRepository {
 
-    suspend fun insertCardElements(cardElements: List<CardElement>): Result<List<Long>>
-
     suspend fun insertCardElement(cardElement: CardElement): Result<Long>
 
     suspend fun deleteCardElementsByCardId(cardId: Long): Result<Int>

--- a/core/domain/src/main/java/com/itschristmas/domain/repository/CardElementRepository.kt
+++ b/core/domain/src/main/java/com/itschristmas/domain/repository/CardElementRepository.kt
@@ -13,15 +13,15 @@ interface CardElementRepository {
 
     suspend fun deleteCardElementsByCardId(cardId: Long): Result<Int>
 
-    suspend fun deleteCardElementById(elementId: Long): Result<Int>
+    suspend fun deleteCardElementById(cardId: Long, elementId: Long): Result<Int>
 
-    suspend fun deleteCardElementsByIds(elementIds: List<Long>): Result<Int>
+    suspend fun deleteCardElementsByIds(cardId: Long, elementIds: List<Long>): Result<Int>
 
     fun getObjectElementsWithAssetKeysByCardId(cardId: Long): Flow<Result<List<CardElementWithAssetKeys>>>
 
     suspend fun getTextElementsByCardId(cardId: Long): Result<List<CardElement>>
 
-    suspend fun updateElementTransform(elementId: Long, posX: Float, posY: Float, posZ: Float, scale: Int): Result<Int>
+    suspend fun updateElementTransform(cardId: Long, elementId: Long, posX: Float, posY: Float, posZ: Float, scale: Int): Result<Int>
 
-    suspend fun updateTextElement(elementId: Long, textAttributes: TextAttributes, posX: Float, posY: Float, posZ: Float): Result<Int>
+    suspend fun updateTextElement(cardId: Long, elementId: Long, textAttributes: TextAttributes, posX: Float, posY: Float, posZ: Float): Result<Int>
 }

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
@@ -270,7 +270,7 @@ class CardEditorViewModel @Inject constructor(
     private fun handleDeleteSpawnedObject() {
         viewModelScope.launch {
             _cardEditorState.value.selectedSpawnedObjectId?.let { id ->
-                cardElementRepository.deleteCardElementById(id)
+                cardElementRepository.deleteCardElementById(_cardId, id)
                     .onSuccess { row ->
                         if(row > 0) unityBridge.deleteObject(id)
                     }
@@ -559,6 +559,7 @@ class CardEditorViewModel @Inject constructor(
 
         viewModelScope.launch {
             cardElementRepository.updateElementTransform(
+                cardId = _cardId,
                 elementId = tempState.elementId,
                 posX = tempState.posX,
                 posY = tempState.posY,

--- a/feature/main/src/main/java/com/itschristmas/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/itschristmas/main/MainScreen.kt
@@ -184,7 +184,7 @@ fun CardGrid(cardItems: List<CardItem>, onCardClick: (Long) -> Unit) {
         items(cardItems) { item ->
             CardItem(
                 cardTitle = item.card.title,
-                createdAt = formatRelativeTime(item.card.createdAt),
+                updatedAt = formatRelativeTime(item.card.updatedAt),
                 thumbnailKey = item.thumbnailKey,
                 onClick = { onCardClick(item.card.cardId) }
             )
@@ -193,7 +193,7 @@ fun CardGrid(cardItems: List<CardItem>, onCardClick: (Long) -> Unit) {
 }
 
 @Composable
-fun CardItem(cardTitle: String, createdAt: String, thumbnailKey: String?, onClick: () -> Unit) {
+fun CardItem(cardTitle: String, updatedAt: String, thumbnailKey: String?, onClick: () -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -221,7 +221,7 @@ fun CardItem(cardTitle: String, createdAt: String, thumbnailKey: String?, onClic
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = createdAt,
+                    text = updatedAt,
                     style = MaterialTheme.typography.labelSmall,
                     fontSize = 8.sp
                 )

--- a/feature/main/src/main/java/com/itschristmas/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/itschristmas/main/MainViewModel.kt
@@ -42,7 +42,7 @@ class MainViewModel @Inject constructor(
                         val thumbnailKey =
                             backgroundList.find { bg -> bg.assetId == it.backgroundAssetId }?.thumbnailKey
                         CardItem(it, thumbnailKey)
-                    }.sortedBy { it.card.updatedAt }.reversed()
+                    }
                 }
                 .onFailure {
                     Log.e(TAG, "getAllCardsFromDB: $it")

--- a/feature/main/src/main/java/com/itschristmas/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/itschristmas/main/MainViewModel.kt
@@ -42,7 +42,7 @@ class MainViewModel @Inject constructor(
                         val thumbnailKey =
                             backgroundList.find { bg -> bg.assetId == it.backgroundAssetId }?.thumbnailKey
                         CardItem(it, thumbnailKey)
-                    }
+                    }.sortedBy { it.card.updatedAt }.reversed()
                 }
                 .onFailure {
                     Log.e(TAG, "getAllCardsFromDB: $it")


### PR DESCRIPTION
## Related Issue
- Close: #61 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카드 요소 편집 시 카드의 수정 시간이 자동으로 갱신됩니다.

* **개선 사항**
  * 카드 목록이 최근 수정 순으로 정렬됩니다.
  * 카드 목록에 생성 날짜 대신 수정 날짜를 표시합니다.

* **리팩토링**
  * 카드 요소 업데이트 작업에 트랜잭션 처리를 적용하여 데이터 무결성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->