### PR TITLE
[Refactor/#63] Card URL 생성 로직 Usecase 분리 및 카드 제목 URL 인코딩 

### DIFF
--- a/core/data/src/main/java/com/itschristmas/data/di/UseCaseModule.kt
+++ b/core/data/src/main/java/com/itschristmas/data/di/UseCaseModule.kt
@@ -1,8 +1,10 @@
 package com.itschristmas.data.di
 
+import com.itschristmas.data.usecaseImpl.GenerateCardUrlUseCaseImpl
 import com.itschristmas.data.usecaseImpl.GetTextElementsUseCaseImpl
 import com.itschristmas.data.usecaseImpl.LoadCardEditorUseCaseImpl
 import com.itschristmas.data.usecaseImpl.SaveTextElementsUseCaseImpl
+import com.itschristmas.domain.usecase.GenerateCardUrlUseCase
 import com.itschristmas.domain.usecase.GetTextElementsUseCase
 import com.itschristmas.domain.usecase.LoadCardEditorUseCase
 import com.itschristmas.domain.usecase.SaveTextElementsUseCase
@@ -14,6 +16,11 @@ import dagger.hilt.components.SingletonComponent
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class UseCaseModule {
+
+    @Binds
+    abstract fun bindGenerateCardUrlUseCase(
+        generateCardUrlUseCaseImpl: GenerateCardUrlUseCaseImpl
+    ): GenerateCardUrlUseCase
 
     @Binds
     abstract fun bindLoadCardEditorUseCase(

--- a/core/data/src/main/java/com/itschristmas/data/usecaseImpl/GenerateCardUrlUseCaseImpl.kt
+++ b/core/data/src/main/java/com/itschristmas/data/usecaseImpl/GenerateCardUrlUseCaseImpl.kt
@@ -1,0 +1,30 @@
+package com.itschristmas.data.usecaseImpl
+
+import com.itschristmas.domain.repository.AssetRepository
+import com.itschristmas.domain.repository.CardRepository
+import com.itschristmas.domain.usecase.GenerateCardUrlUseCase
+import java.net.URLEncoder.encode
+import javax.inject.Inject
+
+class GenerateCardUrlUseCaseImpl @Inject constructor(
+    private val cardRepository: CardRepository,
+    private val assetRepository: AssetRepository
+): GenerateCardUrlUseCase {
+    private val baseCardUrl = "https://its-christmas-1f0ea.web.app"
+
+    override suspend fun invoke(
+        cardId: Long,
+    ): String {
+        val card = cardRepository.getCardById(cardId).getOrNull() ?: return ""
+        val bg = assetRepository.getAssetById(card.backgroundAssetId).getOrNull() ?: return ""
+
+        val encodedTitle = encode(card.title, "UTF-8")
+        val encodedGlb = encode(card.glbFileName, "UTF-8")
+        val encodedGlbToken = encode(card.glbToken, "UTF-8")
+        val encodedBg = encode(bg.firebaseFileName, "UTF-8")
+        val encodedBgToken = encode(bg.firebaseToken, "UTF-8")
+
+        val url = "$baseCardUrl?title=${encodedTitle}&glb=${encodedGlb}&glbToken=${encodedGlbToken}&bg=${encodedBg}&bgToken=${encodedBgToken}"
+        return url
+    }
+}

--- a/core/domain/src/main/java/com/itschristmas/domain/usecase/GenerateCardUrlUseCase.kt
+++ b/core/domain/src/main/java/com/itschristmas/domain/usecase/GenerateCardUrlUseCase.kt
@@ -1,8 +1,9 @@
 package com.itschristmas.domain.usecase
 
 import android.net.Uri
+import javax.inject.Inject
 
-class GenerateCardUrlUseCase {
+class GenerateCardUrlUseCase @Inject constructor() {
 
     private val baseCardUrl = "https://its-christmas-1f0ea.web.app"
 

--- a/core/domain/src/main/java/com/itschristmas/domain/usecase/GenerateCardUrlUseCase.kt
+++ b/core/domain/src/main/java/com/itschristmas/domain/usecase/GenerateCardUrlUseCase.kt
@@ -13,6 +13,7 @@ class GenerateCardUrlUseCase {
         bgFileName: String,
         bgToken: String
     ): String {
-        return "$baseCardUrl?title=$cardTitle&glb=$fileName&glbToken=$token&bg=$bgFileName&bgToken=$bgToken"
+        val encodedTitle = Uri.encode(cardTitle)
+        return "$baseCardUrl?title=$encodedTitle&glb=$fileName&glbToken=$token&bg=$bgFileName&bgToken=$bgToken"
     }
 }

--- a/core/domain/src/main/java/com/itschristmas/domain/usecase/GenerateCardUrlUseCase.kt
+++ b/core/domain/src/main/java/com/itschristmas/domain/usecase/GenerateCardUrlUseCase.kt
@@ -1,0 +1,18 @@
+package com.itschristmas.domain.usecase
+
+import android.net.Uri
+
+class GenerateCardUrlUseCase {
+
+    private val baseCardUrl = "https://its-christmas-1f0ea.web.app"
+
+    operator fun invoke(
+        cardTitle: String,
+        fileName: String,
+        token: String,
+        bgFileName: String,
+        bgToken: String
+    ): String {
+        return "$baseCardUrl?title=$cardTitle&glb=$fileName&glbToken=$token&bg=$bgFileName&bgToken=$bgToken"
+    }
+}

--- a/core/domain/src/main/java/com/itschristmas/domain/usecase/GenerateCardUrlUseCase.kt
+++ b/core/domain/src/main/java/com/itschristmas/domain/usecase/GenerateCardUrlUseCase.kt
@@ -1,20 +1,5 @@
 package com.itschristmas.domain.usecase
 
-import android.net.Uri
-import javax.inject.Inject
-
-class GenerateCardUrlUseCase @Inject constructor() {
-
-    private val baseCardUrl = "https://its-christmas-1f0ea.web.app"
-
-    operator fun invoke(
-        cardTitle: String,
-        fileName: String,
-        token: String,
-        bgFileName: String,
-        bgToken: String
-    ): String {
-        val encodedTitle = Uri.encode(cardTitle)
-        return "$baseCardUrl?title=$encodedTitle&glb=$fileName&glbToken=$token&bg=$bgFileName&bgToken=$bgToken"
-    }
+interface GenerateCardUrlUseCase {
+    suspend operator fun invoke(cardId: Long): String
 }

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
@@ -9,7 +9,6 @@ import com.itschristmas.card.cardeditor.model.PanelType
 import com.itschristmas.card.cardeditor.model.TempTextElement
 import com.itschristmas.card.cardeditor.model.TempTransform
 import com.itschristmas.card.cardeditor.util.extractFileNameAndToken
-import com.itschristmas.card.cardeditor.util.generateCardUrl
 import com.itschristmas.domain.bridge.UnityBridge
 import com.itschristmas.domain.enum.ElementType
 import com.itschristmas.domain.model.Asset
@@ -25,6 +24,7 @@ import com.itschristmas.domain.model.UnityStatusType
 import com.itschristmas.domain.repository.AssetRepository
 import com.itschristmas.domain.repository.CardElementRepository
 import com.itschristmas.domain.repository.CardRepository
+import com.itschristmas.domain.usecase.GenerateCardUrlUseCase
 import com.itschristmas.domain.usecase.GetTextElementsUseCase
 import com.itschristmas.domain.usecase.LoadCardEditorUseCase
 import com.itschristmas.domain.usecase.SaveTextElementsParams
@@ -52,6 +52,7 @@ class CardEditorViewModel @Inject constructor(
     private val loadCardEditorUseCase: LoadCardEditorUseCase,
     private val getTextsUseCase: GetTextElementsUseCase,
     private val saveTextElementsUseCase: SaveTextElementsUseCase,
+    private val generateCardUrl: GenerateCardUrlUseCase,
     private val unityBridge: UnityBridge
 ) : ViewModel() {
 

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
@@ -197,7 +197,8 @@ class CardEditorViewModel @Inject constructor(
                 if(cardUrl.isBlank()) error("Generated card url is blank")
 
                 _cardEditorSideEffect.emit(CardEditorSideEffect.NavigateToCardShare(cardUrl))
-
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Throwable) {
                 Log.e(TAG, "handleExportGlbResult: $e")
                 _cardEditorSideEffect.emit(CardEditorSideEffect.ShowToast("Oops! Card generation failed. Please try again."))

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
@@ -187,21 +187,23 @@ class CardEditorViewModel @Inject constructor(
 
     private fun handleExportGlbResult(unityStatusType: UnityStatusType, result: String) {
         viewModelScope.launch {
-            when (unityStatusType) {
-                UnityStatusType.SUCCESS -> {
-                    val (fileName, token) = extractFileNameAndToken(result)
-                    cardRepository.updateGlb(_cardId, fileName, token)
+            try {
+                if(unityStatusType != UnityStatusType.SUCCESS) error("Export glb failed from Unity")
 
-                    val cardUrl = generateCardUrl(_cardId)
+                val (fileName, token) = extractFileNameAndToken(result)
+                cardRepository.updateGlb(_cardId, fileName, token).getOrThrow()
 
-                    _cardEditorSideEffect.emit(CardEditorSideEffect.NavigateToCardShare(cardUrl))
-                }
-                else -> {
-                    _cardEditorSideEffect.emit(CardEditorSideEffect.ShowToast("Oops! Card creation failed. Please try again."))
-                    Log.e(TAG, "handleExportGlbResult: $result")
-                }
+                val cardUrl = generateCardUrl(_cardId)
+                if(cardUrl.isBlank()) error("Generated card url is blank")
+
+                _cardEditorSideEffect.emit(CardEditorSideEffect.NavigateToCardShare(cardUrl))
+
+            } catch (e: Throwable) {
+                Log.e(TAG, "handleExportGlbResult: $e")
+                _cardEditorSideEffect.emit(CardEditorSideEffect.ShowToast("Oops! Card generation failed. Please try again."))
+            } finally {
+                _cardEditorState.update { it.copy(isLoading = false) }
             }
-            _cardEditorState.update { it.copy(isLoading = false) }
         }
     }
 

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/CardEditorViewModel.kt
@@ -187,21 +187,12 @@ class CardEditorViewModel @Inject constructor(
 
     private fun handleExportGlbResult(unityStatusType: UnityStatusType, result: String) {
         viewModelScope.launch {
-            val state = _cardEditorState.value
             when (unityStatusType) {
                 UnityStatusType.SUCCESS -> {
                     val (fileName, token) = extractFileNameAndToken(result)
-                    val selectedBg = state.backgrounds.firstOrNull { it.assetId == state.selectedBackgroundId }
-
                     cardRepository.updateGlb(_cardId, fileName, token)
 
-                    val cardUrl = generateCardUrl(
-                        cardTitle = state.cardTitle,
-                        fileName = fileName,
-                        token = token,
-                        bgFileName = selectedBg?.firebaseFileName ?: "",
-                        bgToken = selectedBg?.firebaseToken ?: ""
-                    )
+                    val cardUrl = generateCardUrl(_cardId)
 
                     _cardEditorSideEffect.emit(CardEditorSideEffect.NavigateToCardShare(cardUrl))
                 }

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/util/CardEditorUtils.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/util/CardEditorUtils.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.itschristmas.card.R
 
 private const val base62Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-private const val baseCardUrl = "https://its-christmas-1f0ea.web.app"
 
 fun getObjectThumbByKey(context: Context, key: String?): Int {
     if (key == null) return R.drawable.thumb_m_placeholder
@@ -33,14 +32,4 @@ fun extractFileNameAndToken(url: String): Pair<String, String> {
     val token = url.substringAfter("token=")
 
     return fileName to token
-}
-
-fun generateCardUrl(
-    cardTitle: String,
-    fileName: String,
-    token: String,
-    bgFileName: String,
-    bgToken: String
-): String {
-    return "$baseCardUrl?title=$cardTitle&glb=$fileName&glbToken=$token&bg=$bgFileName&bgToken=$bgToken"
 }


### PR DESCRIPTION
## Related Issue
- Close: #63 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카드 ID로부터 안전하게 인코딩된 공유/내보내기 URL을 생성하는 중앙 UseCase와 그 구현 및 DI 바인딩을 추가했습니다.
  * 내보내기 완료 시 생성된 URL로 공유 화면으로 이동하도록 흐름을 개선했습니다.

* **Refactor**
  * 카드 편집기에서 URL 생성 로직을 중앙 UseCase로 전환하고, 기존 공개 유틸리티 함수를 제거해 API 표면과 흐름을 단순화했습니다.
  * 내보내기 오류 시 안내 토스트 표시 및 로딩 상태 관리를 일관되게 처리하도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->