### PR TITLE
[UI/#72] 텍스트 필드 및 텍스트 리스트 스타일 변경 

### DIFF
--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/dialog/CardInfoDialog.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/dialog/CardInfoDialog.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import com.itschristmas.card.R
 import com.itschristmas.card.cardeditor.ui.common.BaseDialog
 import com.itschristmas.designsystem.theme.Gray
+import com.itschristmas.designsystem.theme.White
 
 @Composable
 fun CardInfoDialog(
@@ -57,7 +58,8 @@ fun CardInfoDialog(
                     placeholder = {
                         Text(
                             text = stringResource(R.string.editor_dialog_placeholder_card_title),
-                            style = MaterialTheme.typography.labelSmall
+                            style = MaterialTheme.typography.labelSmall,
+                            color = White
                         )
                     },
                     singleLine = true,

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/dialog/SetCardTitleDialog.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/dialog/SetCardTitleDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import com.itschristmas.card.R
 import com.itschristmas.card.cardeditor.ui.common.BaseDialog
 import com.itschristmas.designsystem.theme.Gray
+import com.itschristmas.designsystem.theme.White
 
 @Composable
 fun SetCardTitleDialog(
@@ -42,7 +43,8 @@ fun SetCardTitleDialog(
             placeholder = {
                 Text(
                     text = stringResource(R.string.editor_dialog_placeholder_card_title),
-                    style = MaterialTheme.typography.labelSmall
+                    style = MaterialTheme.typography.labelSmall,
+                    color = White
                 )
             },
             singleLine = true,

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TextEditorPanel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TextEditorPanel.kt
@@ -207,7 +207,8 @@ private fun EditorHeader(
                     if (text.isEmpty()) {
                         Text(
                             text = stringResource(R.string.editor_placeholder_text),
-                            style = MaterialTheme.typography.labelSmall
+                            style = MaterialTheme.typography.labelSmall,
+                            color = White
                         )
                     }
                     innerTextField()

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TextListPanel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TextListPanel.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -36,6 +37,8 @@ fun TextListPanel(
     selectedTextId: Long = 0,
     onClick: (Long) -> Unit = {}
 ) {
+    val fontFamilies = rememberFontFamilies()
+
     LazyRow(
         modifier = Modifier.padding(horizontal = 10.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -44,7 +47,8 @@ fun TextListPanel(
         items(items = textList, key = { it.tempId }) { text ->
             TextChip(
                 text = text.textElement.attributes.content,
-                fontFamily = text.textElement.attributes.fontFamily.key,
+                fontFamily = fontFamilies[text.textElement.attributes.fontFamily.key]
+                    ?: FontFamily.Default,
                 isSelected = selectedTextId == text.tempId,
                 onClick = { onClick(text.tempId) }
             )
@@ -55,12 +59,10 @@ fun TextListPanel(
 @Composable
 fun TextChip(
     text: String,
-    fontFamily: String,
+    fontFamily: FontFamily,
     isSelected: Boolean,
     onClick: () -> Unit
 ) {
-    val fontFamilies = rememberFontFamilies()
-
     Card(
         modifier = Modifier
             .width(80.dp)
@@ -72,13 +74,15 @@ fun TextChip(
         colors = CardDefaults.cardColors(containerColor = SoftBlack.copy(0.3f))
     ) {
         Box(
-            modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 8.dp),
             contentAlignment = Alignment.Center
         ) {
             Text(
                 text = text,
                 style = MaterialTheme.typography.labelSmall,
-                fontFamily = fontFamilies[fontFamily],
+                fontFamily = fontFamily,
                 color = if (isSelected) White else SoftBlack,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,

--- a/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TextListPanel.kt
+++ b/feature/card/src/main/java/com/itschristmas/card/cardeditor/ui/panels/TextListPanel.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.itschristmas.card.cardeditor.model.TempTextElement
+import com.itschristmas.card.cardeditor.ui.uimapper.rememberFontFamilies
 import com.itschristmas.designsystem.theme.ItsChristmasTheme
 import com.itschristmas.designsystem.theme.SoftBlack
 import com.itschristmas.designsystem.theme.White
@@ -43,6 +44,7 @@ fun TextListPanel(
         items(items = textList, key = { it.tempId }) { text ->
             TextChip(
                 text = text.textElement.attributes.content,
+                fontFamily = text.textElement.attributes.fontFamily.key,
                 isSelected = selectedTextId == text.tempId,
                 onClick = { onClick(text.tempId) }
             )
@@ -53,9 +55,12 @@ fun TextListPanel(
 @Composable
 fun TextChip(
     text: String,
+    fontFamily: String,
     isSelected: Boolean,
     onClick: () -> Unit
 ) {
+    val fontFamilies = rememberFontFamilies()
+
     Card(
         modifier = Modifier
             .width(80.dp)
@@ -73,6 +78,7 @@ fun TextChip(
             Text(
                 text = text,
                 style = MaterialTheme.typography.labelSmall,
+                fontFamily = fontFamilies[fontFamily],
                 color = if (isSelected) White else SoftBlack,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
## Related Issue
- Close: #72 

## Screenshot
- 텍스트 리스트 각 요소에 각각의 폰트 적용
- TextField PlaceHolder 색상 흰색으로 변경
<img width="25%" src="https://github.com/user-attachments/assets/98075af1-c28b-4c42-aae1-84c81e686b04"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 텍스트 칩에서 폰트 패밀리 선택 기능 추가 — 텍스트에 다양한 글꼴 적용 가능

* **Style**
  * 카드 편집 UI의 여러 플레이스홀더 텍스트 색상을 흰색으로 개선하여 가시성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->