### PR TITLE
[Feat/#91] 오브젝트 생성 시 비동기 로드(Addressable) 대응용 개별 로딩 UI 추가

### DIFF
--- a/core/data/src/main/java/com/zcard/data/usecaseImpl/LoadCardEditorUseCaseImpl.kt
+++ b/core/data/src/main/java/com/zcard/data/usecaseImpl/LoadCardEditorUseCaseImpl.kt
@@ -11,6 +11,7 @@ import com.zcard.domain.usecase.LoadCardEditorResult
 import com.zcard.domain.usecase.LoadCardEditorUseCase
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 private const val TAG = "LoadCardEditorUseCaseImpl"
@@ -32,15 +33,17 @@ class LoadCardEditorUseCaseImpl @Inject constructor(
                 val textsDeferred = async { getTextsUseCase(cardId).getOrThrow() }
                 val spawnedObjectsFlow =
                     cardElementRepository.getObjectElementsWithAssetKeysByCardId(cardId)
+                val spawnedObjectsDeferred = async { spawnedObjectsFlow.first().getOrThrow() }
 
-                val cardUrl = generateCardUrlUseCase(cardId)
+                val cardUrlDeferred = async { generateCardUrlUseCase(cardId) }
 
                 LoadCardEditorResult(
                     cardData = cardDataDeferred.await(),
-                    cardUrl = cardUrl,
+                    cardUrl = cardUrlDeferred.await(),
                     objects = objectsDeferred.await(),
                     backgrounds = backgroundsDeferred.await(),
                     texts = textsDeferred.await(),
+                    spawnedObjects = spawnedObjectsDeferred.await(),
                     spawnedObjectsFlow = spawnedObjectsFlow
                 )
             }.onFailure {

--- a/core/database/src/main/java/com/zcard/database/data/InitialData.kt
+++ b/core/database/src/main/java/com/zcard/database/data/InitialData.kt
@@ -19,9 +19,9 @@ object InitialData {
     fun getInitialAssets(): List<AssetEntity> {
         return listOf(
             // 모델
-            //AssetEntity(assetId = 7, assetType = "OBJECT", unityKey = "m_001", thumbnailKey = "thumb_m_001"),
+            AssetEntity(assetId = 7, assetType = "OBJECT", unityKey = "m_001", thumbnailKey = "thumb_m_001"),
             AssetEntity(assetId = 8, assetType = "OBJECT", unityKey = "m_002", thumbnailKey = "thumb_m_002"),
-            //AssetEntity(assetId = 9, assetType = "OBJECT", unityKey = "m_003", thumbnailKey = "thumb_m_003"),
+            AssetEntity(assetId = 9, assetType = "OBJECT", unityKey = "m_003", thumbnailKey = "thumb_m_003"),
             AssetEntity(assetId = 10, assetType = "OBJECT", unityKey = "m_004", thumbnailKey = "thumb_m_004"),
             AssetEntity(assetId = 11, assetType = "OBJECT", unityKey = "m_005", thumbnailKey = "thumb_m_005"),
             AssetEntity(assetId = 12, assetType = "OBJECT", unityKey = "m_006", thumbnailKey = "thumb_m_006"),

--- a/core/domain/src/main/java/com/zcard/domain/model/UnityMessage.kt
+++ b/core/domain/src/main/java/com/zcard/domain/model/UnityMessage.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 
 enum class UnityMessageType {
     LIFECYCLE,
+    CREATE_OBJECT,
     UPLOAD_GLB
 }
 

--- a/core/domain/src/main/java/com/zcard/domain/model/UnityMessage.kt
+++ b/core/domain/src/main/java/com/zcard/domain/model/UnityMessage.kt
@@ -3,22 +3,28 @@ package com.zcard.domain.model
 
 import kotlinx.serialization.Serializable
 
-enum class UnityMessageType {
+enum class UnityEventType {
     LIFECYCLE,
     CREATE_OBJECT,
     UPLOAD_GLB
 }
 
-enum class UnityStatusType {
+enum class UnityEventStatus  {
+    // Result
     SUCCESS,
     FAILURE,
+
+    // Lifecycle
+    AWAKE,
     START,
-    STOP,
+    DISABLE,
+    DESTROY,
+    QUIT
 }
 
 @Serializable
 data class UnityMessage(
-    val type: UnityMessageType,
-    val status: UnityStatusType,
+    val type: UnityEventType,
+    val status: UnityEventStatus,
     val data: String
 )

--- a/core/domain/src/main/java/com/zcard/domain/usecase/LoadCardEditorUseCase.kt
+++ b/core/domain/src/main/java/com/zcard/domain/usecase/LoadCardEditorUseCase.kt
@@ -12,6 +12,7 @@ data class LoadCardEditorResult(
     val objects: List<Asset>,
     val backgrounds: List<Asset>,
     val texts: List<TextElement>,
+    val spawnedObjects: List<CardElementWithAssetKeys>,
     val spawnedObjectsFlow: Flow<Result<List<CardElementWithAssetKeys>>>
 )
 

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorActivity.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorActivity.kt
@@ -31,9 +31,9 @@ import com.zcard.card.cardshare.CardShareActivity
 import com.zcard.card.databinding.ActivityCardEditorBinding
 import com.zcard.designsystem.theme.ZCardTheme
 import com.zcard.domain.model.UnityMessage
-import com.zcard.domain.model.UnityMessageType
-import com.zcard.domain.model.UnityStatusType
 import com.unity3d.player.UnityPlayerForActivityOrService
+import com.zcard.domain.model.UnityEventStatus
+import com.zcard.domain.model.UnityEventType
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -232,19 +232,17 @@ class CardEditorActivity : AppCompatActivity() {
 
     private fun handleUnityMessage(msg: UnityMessage) {
         when (msg.type) {
-            UnityMessageType.LIFECYCLE -> {
-                if (msg.status == UnityStatusType.START) {
+            UnityEventType.LIFECYCLE -> {
+                if (msg.status == UnityEventStatus.START) {
                     viewModel.handleInitUnity()
                     Log.i("UnityMsg", "Unity Started Ready!")
                 }
             }
-            UnityMessageType.CREATE_OBJECT -> {
+            UnityEventType.CREATE_OBJECT -> {
                 viewModel.onIntent(CardEditorIntent.CreateObjectResult(msg.status, msg.data))
             }
-            UnityMessageType.UPLOAD_GLB -> {
-                if(msg.status != UnityStatusType.START) {
-                    viewModel.onIntent(CardEditorIntent.ExportGlbResult(msg.status, msg.data))
-                }
+            UnityEventType.UPLOAD_GLB -> {
+                viewModel.onIntent(CardEditorIntent.ExportGlbResult(msg.status, msg.data))
             }
         }
     }

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorActivity.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorActivity.kt
@@ -238,6 +238,9 @@ class CardEditorActivity : AppCompatActivity() {
                     Log.i("UnityMsg", "Unity Started Ready!")
                 }
             }
+            UnityMessageType.CREATE_OBJECT -> {
+                viewModel.onIntent(CardEditorIntent.CreateObjectResult(msg.status, msg.data))
+            }
             UnityMessageType.UPLOAD_GLB -> {
                 if(msg.status != UnityStatusType.START) {
                     viewModel.onIntent(CardEditorIntent.ExportGlbResult(msg.status, msg.data))

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorIntent.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorIntent.kt
@@ -21,6 +21,7 @@ sealed class CardEditorIntent {
     data object FinishEditing: CardEditorIntent()
     data object ExportGlbAndUpload: CardEditorIntent()
     data class ExportGlbResult(val unityStatusType: UnityStatusType, val result: String): CardEditorIntent()
+    data class CreateObjectResult(val unityStatusType: UnityStatusType, val result: String): CardEditorIntent()
     data class ChangeDialogState(val dialogState: DialogState): CardEditorIntent()
 
     data class CreateObject(val clickedObject: Asset): CardEditorIntent()
@@ -32,7 +33,7 @@ sealed class CardEditorIntent {
 
     data object ResetCamera: CardEditorIntent()
 
-    /* 오브젝트 조정 */
+    /* 오브젝트 조정 패널 */
     data class MoveObject(val direction: Direction): CardEditorIntent()
     data class ChangeScale(val newScale: Int): CardEditorIntent()
     data object CancelTransform: CardEditorIntent()
@@ -42,7 +43,7 @@ sealed class CardEditorIntent {
     data object ResetTransform: CardEditorIntent()
     data object CameraFocus: CardEditorIntent()
 
-    /* 텍스트 편집 */
+    /* 텍스트 편집 패널 */
     data object MissingTextSelection: CardEditorIntent()
     data object AddText: CardEditorIntent()
     data class DeleteText(val textId: Long): CardEditorIntent()

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorIntent.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorIntent.kt
@@ -7,7 +7,7 @@ import com.zcard.domain.model.CardElementWithAssetKeys
 import com.zcard.domain.model.ColorOption
 import com.zcard.domain.model.FontOption
 import com.zcard.domain.model.TextAlignmentOption
-import com.zcard.domain.model.UnityStatusType
+import com.zcard.domain.model.UnityEventStatus
 
 sealed class CardEditorIntent {
     data class Init(val cardId: Long): CardEditorIntent()
@@ -20,8 +20,8 @@ sealed class CardEditorIntent {
 
     data object FinishEditing: CardEditorIntent()
     data object ExportGlbAndUpload: CardEditorIntent()
-    data class ExportGlbResult(val unityStatusType: UnityStatusType, val result: String): CardEditorIntent()
-    data class CreateObjectResult(val unityStatusType: UnityStatusType, val result: String): CardEditorIntent()
+    data class ExportGlbResult(val unityResult: UnityEventStatus, val result: String): CardEditorIntent()
+    data class CreateObjectResult(val unityResult: UnityEventStatus, val result: String): CardEditorIntent()
     data class ChangeDialogState(val dialogState: DialogState): CardEditorIntent()
 
     data class CreateObject(val clickedObject: Asset): CardEditorIntent()

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorState.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorState.kt
@@ -22,6 +22,7 @@ data class CardEditorState(
     val backgrounds: List<Asset> = emptyList(),
     val spawnedObjects: List<CardElementWithAssetKeys> = emptyList(),
     val texts: List<TextElement> = emptyList(),
+    val loadingObjectIds: Set<Long> = emptySet(),
     val selectedBackgroundId: Long = 1,
     val selectedSpawnedObject: CardElementWithAssetKeys? = null,
     val selectedTextTempId: Long? = null,

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorViewModel.kt
@@ -97,6 +97,7 @@ class CardEditorViewModel @Inject constructor(
             is CardEditorIntent.FinishEditing -> handleFinishEditing()
             is CardEditorIntent.ExportGlbAndUpload -> handleExportGlbAndUpload()
             is CardEditorIntent.ExportGlbResult -> handleExportGlbResult(intent.unityStatusType, intent.result)
+            is CardEditorIntent.CreateObjectResult -> { }
             is CardEditorIntent.ChangeDialogState -> handleChangeDialogState(intent.dialogState)
 
             is CardEditorIntent.CreateObject -> handleCreateObject(intent.clickedObject)
@@ -108,7 +109,7 @@ class CardEditorViewModel @Inject constructor(
 
             is CardEditorIntent.ResetCamera -> handleResetCamera()
 
-            /* 오브젝트 조정 */
+            /* 오브젝트 조정 패널 */
             is CardEditorIntent.MoveObject -> handleMoveObject(intent.direction)
             is CardEditorIntent.ChangeScale -> handleChangeScale(intent.newScale)
             is CardEditorIntent.CancelTransform -> handleCancelTransform()
@@ -118,7 +119,7 @@ class CardEditorViewModel @Inject constructor(
             is CardEditorIntent.ResetTransform -> handleResetTransform()
             is CardEditorIntent.CameraFocus -> handleCameraFocus()
 
-            /* 텍스트 편집 */
+            /* 텍스트 편집 패널 */
             is CardEditorIntent.MissingTextSelection -> handleMissingTextSelection()
             is CardEditorIntent.AddText -> handleAddText()
             is CardEditorIntent.DeleteText -> handleDeleteText(intent.textId)

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorViewModel.kt
@@ -97,7 +97,7 @@ class CardEditorViewModel @Inject constructor(
             is CardEditorIntent.FinishEditing -> handleFinishEditing()
             is CardEditorIntent.ExportGlbAndUpload -> handleExportGlbAndUpload()
             is CardEditorIntent.ExportGlbResult -> handleExportGlbResult(intent.unityStatusType, intent.result)
-            is CardEditorIntent.CreateObjectResult -> { }
+            is CardEditorIntent.CreateObjectResult -> handleCreateObjectResult(intent.unityStatusType, intent.result)
             is CardEditorIntent.ChangeDialogState -> handleChangeDialogState(intent.dialogState)
 
             is CardEditorIntent.CreateObject -> handleCreateObject(intent.clickedObject)
@@ -150,7 +150,8 @@ class CardEditorViewModel @Inject constructor(
                             selectedBackgroundId = result.cardData.backgroundAssetId,
                             objects = result.objects,
                             texts = result.texts,
-                            backgrounds = result.backgrounds
+                            backgrounds = result.backgrounds,
+                            loadingObjectIds = result.spawnedObjects.map { obj -> obj.cardElement.elementId }.toSet()
                         )
                     }
                     observeSpawnedObjects(result.spawnedObjectsFlow)
@@ -164,10 +165,12 @@ class CardEditorViewModel @Inject constructor(
     }
 
     private fun observeSpawnedObjects(flow: Flow<Result<List<CardElementWithAssetKeys>>>) {
+        // Room Flow는 cold flow 이므로 collect를 시작할 때마다 새로 데이터를 읽어서 emit
         flow.onEach { result ->
             result.onSuccess { objects ->
-                _cardEditorState.update {
-                    it.copy(spawnedObjects = objects.asReversed())
+                _cardEditorState.update { it.copy(spawnedObjects = objects) }
+                _cardEditorState.value.spawnedObjects.firstOrNull()?.let {
+                    selectSpawnedObject(it)
                 }
             }
         }.launchIn(viewModelScope)
@@ -244,6 +247,19 @@ class CardEditorViewModel @Inject constructor(
         }
     }
 
+    private fun handleCreateObjectResult(unityStatusType: UnityStatusType, result: String) {
+        viewModelScope.launch {
+            if(unityStatusType != UnityStatusType.SUCCESS) {
+                Log.e(TAG, "Id $result Object Creation Failed")
+                _cardEditorSideEffect.emit(CardEditorSideEffect.ShowToast("Oops! Load Object failed. Please try again."))
+            }
+            result.toLongOrNull()?.let { id ->
+                _cardEditorState.update { it.copy(loadingObjectIds = it.loadingObjectIds - id) }
+                unityBridge.selectObject(id)
+            }
+        }
+    }
+
     private fun handleChangeDialogState(dialogState: DialogState) {
         updateDialogState(dialogState)
     }
@@ -259,6 +275,7 @@ class CardEditorViewModel @Inject constructor(
             )
             cardElementRepository.insertCardElement(newElement)
                 .onSuccess { id ->
+                    _cardEditorState.update { it.copy(loadingObjectIds = it.loadingObjectIds + id) }
                     unityBridge.createObject(
                         unityKey = clickedObject.unityKey,
                         elementId = id,
@@ -285,17 +302,7 @@ class CardEditorViewModel @Inject constructor(
     }
 
     private fun handleSelectSpawnedObject(element: CardElementWithAssetKeys) {
-        val alreadySelected = _cardEditorState.value.selectedSpawnedObjectId == element.cardElement.elementId
-
-        _cardEditorState.update {
-            it.copy(selectedSpawnedObject = if (alreadySelected) null else element)
-        }
-
-        if (alreadySelected) {
-            unityBridge.clearSelection()
-        } else {
-            unityBridge.selectObject(element.cardElement.elementId)
-        }
+        selectSpawnedObject(element)
     }
 
     private fun handleDeleteSpawnedObject() {
@@ -364,7 +371,7 @@ class CardEditorViewModel @Inject constructor(
         unityBridge.clearSelection()
     }
 
-    /* 오브젝트 조정 */
+    /* 오브젝트 조정 패널 */
     private fun handleMoveObject(direction: Direction) {
         val tempState = _cardEditorState.value.tempTransform ?: return
         val updatedPosX = tempState.posX + direction.dx
@@ -446,7 +453,7 @@ class CardEditorViewModel @Inject constructor(
         _cardEditorState.update { it.copy(isTransformCameraFocus = !cameraFocus) }
     }
 
-    /* 텍스트 편집 */
+    /* 텍스트 편집 패널 */
     private fun handleMissingTextSelection() {
         if (_cardEditorState.value.tempTextList.isNotEmpty() && _cardEditorState.value.selectedTextTempId == null) {
             _cardEditorState.update { it.copy(selectedTextTempId = it.tempTextList.first().tempId) }
@@ -582,6 +589,20 @@ class CardEditorViewModel @Inject constructor(
                 } else item
             }
             it.copy(tempTextList = newList)
+        }
+    }
+
+    private fun selectSpawnedObject(element: CardElementWithAssetKeys) {
+        val alreadySelected = _cardEditorState.value.selectedSpawnedObjectId == element.cardElement.elementId
+
+        _cardEditorState.update {
+            it.copy(selectedSpawnedObject = if (alreadySelected) null else element)
+        }
+
+        if (alreadySelected) {
+            unityBridge.clearSelection()
+        } else {
+            unityBridge.selectObject(element.cardElement.elementId)
         }
     }
 

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorViewModel.kt
@@ -19,7 +19,7 @@ import com.zcard.domain.model.FontOption
 import com.zcard.domain.model.TextAlignmentOption
 import com.zcard.domain.model.TextAttributes
 import com.zcard.domain.model.TextElement
-import com.zcard.domain.model.UnityStatusType
+import com.zcard.domain.model.UnityEventStatus
 import com.zcard.domain.repository.AssetRepository
 import com.zcard.domain.repository.CardElementRepository
 import com.zcard.domain.repository.CardRepository
@@ -96,8 +96,8 @@ class CardEditorViewModel @Inject constructor(
 
             is CardEditorIntent.FinishEditing -> handleFinishEditing()
             is CardEditorIntent.ExportGlbAndUpload -> handleExportGlbAndUpload()
-            is CardEditorIntent.ExportGlbResult -> handleExportGlbResult(intent.unityStatusType, intent.result)
-            is CardEditorIntent.CreateObjectResult -> handleCreateObjectResult(intent.unityStatusType, intent.result)
+            is CardEditorIntent.ExportGlbResult -> handleExportGlbResult(intent.unityResult, intent.result)
+            is CardEditorIntent.CreateObjectResult -> handleCreateObjectResult(intent.unityResult, intent.result)
             is CardEditorIntent.ChangeDialogState -> handleChangeDialogState(intent.dialogState)
 
             is CardEditorIntent.CreateObject -> handleCreateObject(intent.clickedObject)
@@ -224,10 +224,10 @@ class CardEditorViewModel @Inject constructor(
         _cardEditorState.update { it.copy(isLoading = true) }
     }
 
-    private fun handleExportGlbResult(unityStatusType: UnityStatusType, result: String) {
+    private fun handleExportGlbResult(unityStatusType: UnityEventStatus, result: String) {
         viewModelScope.launch {
             try {
-                if(unityStatusType != UnityStatusType.SUCCESS) error("Export glb failed from Unity")
+                if(unityStatusType != UnityEventStatus.SUCCESS) error(result)
 
                 val (fileName, token) = extractFileNameAndToken(result)
                 cardRepository.updateGlb(_cardId, fileName, token).getOrThrow()
@@ -247,9 +247,9 @@ class CardEditorViewModel @Inject constructor(
         }
     }
 
-    private fun handleCreateObjectResult(unityStatusType: UnityStatusType, result: String) {
+    private fun handleCreateObjectResult(unityStatusType: UnityEventStatus, result: String) {
         viewModelScope.launch {
-            if(unityStatusType != UnityStatusType.SUCCESS) {
+            if(unityStatusType != UnityEventStatus.SUCCESS) {
                 Log.e(TAG, "Id $result Object Creation Failed")
                 _cardEditorSideEffect.emit(CardEditorSideEffect.ShowToast("Oops! Load Object failed. Please try again."))
             }

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorViewModel.kt
@@ -169,9 +169,6 @@ class CardEditorViewModel @Inject constructor(
         flow.onEach { result ->
             result.onSuccess { objects ->
                 _cardEditorState.update { it.copy(spawnedObjects = objects) }
-                _cardEditorState.value.spawnedObjects.firstOrNull()?.let {
-                    selectSpawnedObject(it)
-                }
             }
         }.launchIn(viewModelScope)
     }
@@ -249,14 +246,22 @@ class CardEditorViewModel @Inject constructor(
 
     private fun handleCreateObjectResult(unityStatusType: UnityEventStatus, result: String) {
         viewModelScope.launch {
+            val id = result.toLongOrNull() ?: return@launch
+
+            // 오브젝트 생성 실패 시에도 Unity 에 해당 ID로 대체 큐브가 생성됨
             if(unityStatusType != UnityEventStatus.SUCCESS) {
                 Log.e(TAG, "Id $result Object Creation Failed")
                 _cardEditorSideEffect.emit(CardEditorSideEffect.ShowToast("Oops! Load Object failed. Please try again."))
             }
-            result.toLongOrNull()?.let { id ->
-                _cardEditorState.update { it.copy(loadingObjectIds = it.loadingObjectIds - id) }
-                unityBridge.selectObject(id)
+
+            _cardEditorState.update {
+                val selectedObject = _cardEditorState.value.spawnedObjects.find { obj -> obj.cardElement.elementId == id }
+                it.copy(
+                    loadingObjectIds = it.loadingObjectIds - id,
+                    selectedSpawnedObject = selectedObject
+                )
             }
+            unityBridge.selectObject(id)
         }
     }
 
@@ -302,7 +307,17 @@ class CardEditorViewModel @Inject constructor(
     }
 
     private fun handleSelectSpawnedObject(element: CardElementWithAssetKeys) {
-        selectSpawnedObject(element)
+        val alreadySelected = _cardEditorState.value.selectedSpawnedObjectId == element.cardElement.elementId
+
+        _cardEditorState.update {
+            it.copy(selectedSpawnedObject = if (alreadySelected) null else element)
+        }
+
+        if (alreadySelected) {
+            unityBridge.clearSelection()
+        } else {
+            unityBridge.selectObject(element.cardElement.elementId)
+        }
     }
 
     private fun handleDeleteSpawnedObject() {
@@ -589,20 +604,6 @@ class CardEditorViewModel @Inject constructor(
                 } else item
             }
             it.copy(tempTextList = newList)
-        }
-    }
-
-    private fun selectSpawnedObject(element: CardElementWithAssetKeys) {
-        val alreadySelected = _cardEditorState.value.selectedSpawnedObjectId == element.cardElement.elementId
-
-        _cardEditorState.update {
-            it.copy(selectedSpawnedObject = if (alreadySelected) null else element)
-        }
-
-        if (alreadySelected) {
-            unityBridge.clearSelection()
-        } else {
-            unityBridge.selectObject(element.cardElement.elementId)
         }
     }
 

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorViewModel.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/CardEditorViewModel.kt
@@ -151,6 +151,7 @@ class CardEditorViewModel @Inject constructor(
                             objects = result.objects,
                             texts = result.texts,
                             backgrounds = result.backgrounds,
+                            spawnedObjects = result.spawnedObjects,
                             loadingObjectIds = result.spawnedObjects.map { obj -> obj.cardElement.elementId }.toSet()
                         )
                     }

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/ui/CardEditorBottomScreen.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/ui/CardEditorBottomScreen.kt
@@ -28,6 +28,7 @@ fun CardEditorBottomScreen(viewModel: CardEditorViewModel = hiltViewModel()) {
                 spawnedObjects = state.spawnedObjects,
                 selectedSpawnedObject = state.selectedSpawnedObjectId,
                 selectedBackground = state.selectedBackgroundId,
+                loadingObjectIds = state.loadingObjectIds,
                 onAddTextClicked = { viewModel.onIntent(CardEditorIntent.EnterTextMode) },
                 onObjectClicked = { viewModel.onIntent(CardEditorIntent.CreateObject(it)) },
                 onSpawnedObjectClicked = { viewModel.onIntent(CardEditorIntent.SelectSpawnedObject(it)) },

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/ui/panels/AssetBrowserPanel.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/ui/panels/AssetBrowserPanel.kt
@@ -191,6 +191,7 @@ fun SpawnedObjectRow(
         ) {
             item { Box(Modifier.size(8.dp)) }
             items(items = elements, key = { it.cardElement.elementId }) { element ->
+                val isLoading = isLoading(element.cardElement.elementId)
                 Box(
                     modifier = Modifier
                         .size(72.dp)
@@ -200,14 +201,13 @@ fun SpawnedObjectRow(
                             RoundedCornerShape(10.dp)
                         )
                         .clip(RoundedCornerShape(10.dp))
+                        .clickable(!isLoading) { onItemClicked(element) }
                 ) {
                     Image(
                         painter = painterResource(id = getObjectThumbByKey(context, element.thumbnailKey)),
                         contentScale = ContentScale.Crop,
                         contentDescription = stringResource(R.string.editor_cd_asset),
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .clickable { onItemClicked(element) }
+                        modifier = Modifier.fillMaxSize()
                     )
                     Box(
                         modifier = Modifier
@@ -222,7 +222,7 @@ fun SpawnedObjectRow(
                             style = MaterialTheme.typography.labelSmall,
                         )
                     }
-                    if (isLoading(element.cardElement.elementId)) {
+                    if (isLoading) {
                         Box(
                             modifier = Modifier
                                 .matchParentSize()

--- a/feature/card/src/main/java/com/zcard/card/cardeditor/ui/panels/AssetBrowserPanel.kt
+++ b/feature/card/src/main/java/com/zcard/card/cardeditor/ui/panels/AssetBrowserPanel.kt
@@ -56,6 +56,7 @@ fun AssetBrowserPanel(
     spawnedObjects: List<CardElementWithAssetKeys> = emptyList(),
     selectedSpawnedObject: Long? = null,
     selectedBackground: Long = 1,
+    loadingObjectIds: Set<Long> = emptySet(),
     onAddTextClicked: () -> Unit = {},
     onObjectClicked: (Asset) -> Unit = {},
     onSpawnedObjectClicked: (CardElementWithAssetKeys) -> Unit = {},
@@ -71,6 +72,7 @@ fun AssetBrowserPanel(
         spawnedObjects = spawnedObjects,
         selectedSpawnedObject = selectedSpawnedObject,
         selectedBackground = selectedBackground,
+        loadingObjectIds = loadingObjectIds,
         onTabSelected = { selectedTab = it },
         onAddTextClicked = onAddTextClicked,
         onObjectClicked = onObjectClicked,
@@ -88,6 +90,7 @@ fun AssetBrowserPanelContent(
     spawnedObjects: List<CardElementWithAssetKeys>,
     selectedSpawnedObject: Long?,
     selectedBackground: Long,
+    loadingObjectIds: Set<Long>,
     onTabSelected: (AssetBrowserTab) -> Unit,
     onObjectClicked: (Asset) -> Unit,
     onSpawnedObjectClicked: (CardElementWithAssetKeys) -> Unit,
@@ -109,7 +112,8 @@ fun AssetBrowserPanelContent(
                 SpawnedObjectRow(
                     elements = spawnedObjects,
                     selectedItemIndex = selectedSpawnedObject,
-                    onItemClicked = { onSpawnedObjectClicked(it) }
+                    onItemClicked = { onSpawnedObjectClicked(it) },
+                    isLoading = { id -> loadingObjectIds.contains(id) }
                 )
             }
             ObjectClickableGrid(
@@ -169,7 +173,8 @@ fun ControlHeader(
 fun SpawnedObjectRow(
     elements: List<CardElementWithAssetKeys>,
     selectedItemIndex: Long?,
-    onItemClicked: (CardElementWithAssetKeys) -> Unit
+    onItemClicked: (CardElementWithAssetKeys) -> Unit,
+    isLoading: (Long) -> Boolean
 ) {
     val context = LocalContext.current
 
@@ -216,6 +221,20 @@ fun SpawnedObjectRow(
                             text = toBase62(element.cardElement.elementId),
                             style = MaterialTheme.typography.labelSmall,
                         )
+                    }
+                    if (isLoading(element.cardElement.elementId)) {
+                        Box(
+                            modifier = Modifier
+                                .matchParentSize()
+                                .background(Color.White.copy(alpha = 0.6f)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                color = SoftBlack,
+                                strokeWidth = 2.dp,
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Related Issue
- Close: #91 

## Description
- Unity 에셋 로드 방식을 Addressable로 전환하며 발생한 Android UI와 Unity 씬 간의 오브젝트 생성 비동기 타이밍 불일치(Race Condition) 해결

## AS-IS
- DB Insert 시 `Flow`를 통해 UI는 즉시 갱신되나, `Addressable`을 사용하는 Unity에서 에셋을 로드하고 Instantiate 하는 데 시간이 걸려 사용자가 일시적으로 빈 오브젝트 화면을 보게 됨

## TO-BE
- 오브젝트 생성 요청 시 DB에 넣고, UI에 **개별 로딩 스피너(Loading UI)** 를 먼저 노출
- Unity에서 오브젝트 렌더링 완료 후 전송하는 **성공 콜백(Signal)** 을 수신하여 로딩 UI를 해제하도록 상태 동기화 로직 구현

## Screenshot
<img width="25%" src="https://github.com/user-attachments/assets/3351f08c-3558-4ea0-9c18-4503bc472ce2"/>
<img width="25%" src="https://github.com/user-attachments/assets/0c871139-6dbf-41ad-8a54-9d7a561055f0"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카드 편집기에서 Unity로 객체 생성 결과 처리 및 생성 흐름 추가
  * 생성 중인 객체에 대해 에셋 목록에서 개별 로딩 표시(오버레이 + 인디케이터) 제공
  * 초기 에셋 2종(m_001, m_003) 활성화로 디자인 옵션 확장

* **향상**
  * 객체 생성 시 로딩 상태 추적 및 생성 완료 후 자동 선택/포커스 동작 개선
  * 내보내기 결과 처리와 관련된 상태/오류 처리가 더 일관성 있게 동작하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->