### PR TITLE
[UI/#95] 메인 화면 UI 디자인 변경 

### DIFF
--- a/core/designsystem/src/main/java/com/zcard/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/zcard/designsystem/theme/Color.kt
@@ -5,4 +5,5 @@ import androidx.compose.ui.graphics.Color
 val White = Color(0xFFFFFFFF)
 val SoftBlack = Color(0xFF2F2F2F)
 val Gray = Color(0xFFEDEDED)
+val DimGray = Color(0xFF969696)
 val Orange = Color(0xFFFF8500)

--- a/feature/main/src/main/java/com/zcard/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/zcard/main/MainScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -40,6 +41,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -49,6 +51,7 @@ import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
+import com.zcard.designsystem.theme.DimGray
 import com.zcard.designsystem.theme.Gray
 import com.zcard.designsystem.theme.ZCardTheme
 import com.zcard.designsystem.theme.SoftBlack
@@ -81,13 +84,9 @@ fun MainContent(modifier: Modifier = Modifier, cardItems: List<CardItem>, onCard
         Column(modifier = Modifier.padding(horizontal = 16.dp)) {
             CreateCardButton(onClick = { onCardClick(-1) })
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(26.dp))
 
-            if(cardItems.isEmpty()) {
-                EmptyCardSection()
-            } else {
-                CardGrid(cardItems = cardItems, onCardClick = onCardClick)
-            }
+            CardDashboard(cardItems = cardItems, onCardClick = onCardClick)
         }
     }
 }
@@ -106,7 +105,7 @@ fun PreviewGifImage() {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .fillMaxHeight(0.40f)
+            .fillMaxHeight(0.35f)
             .clip(
                 RoundedCornerShape(
                     bottomStart = 50.dp,
@@ -128,14 +127,29 @@ fun PreviewGifImage() {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(SoftBlack.copy(alpha = 0.3f))
-        )
-        Text(
-            modifier = Modifier.padding(top = 20.dp),
-            color = White,
-            fontWeight = FontWeight.Light,
-            text = stringResource(R.string.main_title_design_card_prompt)
-        )
+                .background(SoftBlack.copy(alpha = 0.4f))
+                .padding(start = 42.dp, bottom = 38.dp),
+            contentAlignment = Alignment.BottomStart,
+        ) {
+            Column {
+                Text(
+                    color = White,
+                    textAlign = TextAlign.Start,
+                    fontWeight = FontWeight.ExtraLight,
+                    letterSpacing = 0.4.sp,
+                    fontSize = 12.sp,
+                    text = stringResource(R.string.main_title_design_card_sub_prompt)
+                )
+                Text(
+                    color = White,
+                    textAlign = TextAlign.Start,
+                    fontWeight = FontWeight.ExtraBold,
+                    letterSpacing = 0.4.sp,
+                    fontSize = 20.sp,
+                    text = stringResource(R.string.main_title_design_card_prompt)
+                )
+            }
+        }
     }
 }
 
@@ -172,6 +186,23 @@ fun CreateCardButton(onClick: () -> Unit) {
 }
 
 @Composable
+fun CardDashboard(cardItems: List<CardItem> = emptyList(), onCardClick: (Long) -> Unit = {}) {
+    Text(
+        modifier = Modifier.padding(horizontal = 14.dp),
+        text = "Recent Cards",
+        style = MaterialTheme.typography.bodyMedium
+    )
+
+    Spacer(modifier = Modifier.height(10.dp))
+
+    if(cardItems.isEmpty()) {
+        EmptyCardSection()
+    } else {
+        CardGrid(cardItems = cardItems, onCardClick = onCardClick)
+    }
+}
+
+@Composable
 fun CardGrid(cardItems: List<CardItem>, onCardClick: (Long) -> Unit) {
     LazyVerticalStaggeredGrid(
         columns = StaggeredGridCells.Fixed(2),
@@ -180,7 +211,7 @@ fun CardGrid(cardItems: List<CardItem>, onCardClick: (Long) -> Unit) {
             .navigationBarsPadding(),
         contentPadding = PaddingValues(8.dp),
         horizontalArrangement = Arrangement.spacedBy(18.dp),
-        verticalItemSpacing = 20.dp
+        verticalItemSpacing = 18.dp
     ) {
         items(cardItems) { item ->
             CardItem(
@@ -195,38 +226,40 @@ fun CardGrid(cardItems: List<CardItem>, onCardClick: (Long) -> Unit) {
 
 @Composable
 fun CardItem(cardTitle: String, updatedAt: String, thumbnailKey: String?, onClick: () -> Unit) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(120.dp)
-            .clickable { onClick() },
-        shape = CardDefaults.shape,
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
-    ) {
-        Box(contentAlignment = Alignment.Center) {
-            Image(
-                modifier = Modifier.fillMaxSize(),
-                painter = painterResource(getBgThumbByKey(thumbnailKey)),
-                contentDescription = stringResource(R.string.main_cd_card),
-                contentScale = ContentScale.Crop
-            )
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(White.copy(alpha = 0.6f)),
-            )
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(
-                    text = cardTitle,
-                    style = MaterialTheme.typography.labelSmall
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = updatedAt,
-                    style = MaterialTheme.typography.labelSmall,
-                    fontSize = 8.sp
+    Column {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1.4f)
+                .clickable { onClick() },
+            shape = CardDefaults.shape,
+            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Image(
+                    modifier = Modifier.fillMaxSize(),
+                    painter = painterResource(getBgThumbByKey(thumbnailKey)),
+                    contentDescription = stringResource(R.string.main_cd_card),
+                    contentScale = ContentScale.Crop
                 )
             }
+        }
+        Spacer(modifier = Modifier.height(10.dp))
+        Column(
+            modifier = Modifier.padding(horizontal = 6.dp),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Text(
+                text = cardTitle,
+                style = MaterialTheme.typography.labelSmall
+            )
+            Spacer(modifier = Modifier.height(3.dp))
+            Text(
+                text = updatedAt,
+                color = DimGray,
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 8.sp
+            )
         }
     }
 }

--- a/feature/main/src/main/java/com/zcard/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/zcard/main/MainScreen.kt
@@ -189,7 +189,7 @@ fun CreateCardButton(onClick: () -> Unit) {
 fun CardDashboard(cardItems: List<CardItem> = emptyList(), onCardClick: (Long) -> Unit = {}) {
     Text(
         modifier = Modifier.padding(horizontal = 14.dp),
-        text = "Recent Cards",
+        text = stringResource(R.string.main_title_card_dashboard),
         style = MaterialTheme.typography.bodyMedium
     )
 

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="main_cd_async_image">Card Creation Preview</string>
-    <string name="main_title_design_card_prompt">Design Your Own 3D Card!</string>
+    <string name="main_title_design_card_sub_prompt">Imagine More</string>
+    <string name="main_title_design_card_prompt">Create Stunning\n3D Cards</string>
     <string name="main_button_create">Create new card</string>
     <string name="main_cd_arrow_forward_icon">Arrow Forward</string>
     <string name="main_cd_card">Card Preview Image</string>

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="main_title_design_card_sub_prompt">Imagine More</string>
     <string name="main_title_design_card_prompt">Create Stunning\n3D Cards</string>
     <string name="main_button_create">Create new card</string>
+    <string name="main_title_card_dashboard">Recent Cards</string>
     <string name="main_cd_arrow_forward_icon">Arrow Forward</string>
     <string name="main_cd_card">Card Preview Image</string>
     <string name="main_cd_empty_card_icon">Empty Card</string>


### PR DESCRIPTION
## Related Issue
- Close: #95 

## Screenshots
- 변경 전 → 후
<img width="25%" src="https://github.com/user-attachments/assets/8055ea98-69c9-427b-99d5-177315883ca1"/>
<img width="25%" src="https://github.com/user-attachments/assets/d25c1aff-bccf-4204-8bd9-b8ece053ce2f"/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 최근 카드 목록을 단일 대시보드 형태로 통합하여 카드 표시 방식 개선

* **스타일**
  * 카드 레이아웃, 비율 및 간격 조정으로 시각적 정렬 개선
  * 카드 미리보기 섹션 디자인 및 오버레이 업데이트
  * 카드 하단 텍스트 스타일(색상/크기) 조정

* **문구**
  * 메인 화면 메시지 업데이트: "Create Stunning\n3D Cards" 및 "Imagine More"
  * 새 섹션 제목 추가: "Recent Cards"

* **디자인 시스템**
  * 새로운 회색 계열 색상 추가하여 팔레트 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->