### PR TITLE
[Fix/#125] Configuration 변화 시 Unity Process Kill로 인한 앱 종료 문제 해결 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
         <activity
             android:name="com.zcard.feature.MainActivity"
             android:exported="true"
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.ZCard" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/feature/src/main/java/com/zcard/feature/MainActivity.kt
+++ b/feature/src/main/java/com/zcard/feature/MainActivity.kt
@@ -162,11 +162,6 @@ class MainActivity : AppCompatActivity() {
         super.onConfigurationChanged(newConfig)
 
         val diff = lastConfig?.diff(newConfig) ?: return
-        val intent = packageManager.getLaunchIntentForPackage(packageName)
-        if (intent == null) {
-            Log.e("ConfigCheck", "Failed to get launch intent for package: $packageName")
-            return
-        }
         val isOrientationChanged = (diff and ActivityInfo.CONFIG_ORIENTATION) != 0 || (diff and ActivityInfo.CONFIG_SCREEN_SIZE) != 0
 
         if (isOrientationChanged) {
@@ -181,7 +176,11 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun restartApp() {
-        val intent = packageManager.getLaunchIntentForPackage(packageName) ?: return
+        val intent = packageManager.getLaunchIntentForPackage(packageName)
+        if (intent == null) {
+            Log.e("ConfigCheck", "Failed to get launch intent for package: $packageName")
+            return
+        }
         // CLEAR_TASK: 기존 태스크 스택 전체 제거 후 새 태스크에서 재시작
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
         startActivity(intent)

--- a/feature/src/main/java/com/zcard/feature/MainActivity.kt
+++ b/feature/src/main/java/com/zcard/feature/MainActivity.kt
@@ -162,9 +162,13 @@ class MainActivity : AppCompatActivity() {
         super.onConfigurationChanged(newConfig)
 
         val diff = lastConfig?.diff(newConfig) ?: return
+        val criticalMask = ActivityInfo.CONFIG_UI_MODE or  // 다크모드
+                ActivityInfo.CONFIG_LOCALE or   // 언어 변경
+                ActivityInfo.CONFIG_FONT_SCALE  // 글꼴 크기
+
         val isOrientationChanged = (diff and ActivityInfo.CONFIG_ORIENTATION) != 0 || (diff and ActivityInfo.CONFIG_SCREEN_SIZE) != 0
 
-        if (isOrientationChanged) {
+        if (isOrientationChanged && (diff and criticalMask) == 0) {
             Log.i("ConfigCheck", "🟢 Orientation change detected → keep Unity engine (orientation=${newConfig.orientation})")
             unityPlayer.configurationChanged(newConfig)
         } else {

--- a/feature/src/main/java/com/zcard/feature/MainActivity.kt
+++ b/feature/src/main/java/com/zcard/feature/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.zcard.feature
 
 import android.annotation.SuppressLint
+import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
@@ -28,11 +30,13 @@ class MainActivity : AppCompatActivity() {
     private lateinit var unityPlayer: UnityPlayerForActivityOrService
     private lateinit var layoutParams: ConstraintLayout.LayoutParams
     private val viewModel: MainViewModel by viewModels()
+    private var lastConfig: Configuration? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         layoutParams = binding.unityContainer.layoutParams as ConstraintLayout.LayoutParams
+        lastConfig = resources.configuration
 
         setContentView(binding.root)
 
@@ -156,6 +160,28 @@ class MainActivity : AppCompatActivity() {
     // 레이아웃에 따른 Unity 맵핑
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        unityPlayer.configurationChanged(newConfig)
+
+        val diff = lastConfig?.diff(newConfig) ?: return
+        val isOrientationChanged = (diff and ActivityInfo.CONFIG_ORIENTATION) != 0 || (diff and ActivityInfo.CONFIG_SCREEN_SIZE) != 0
+
+        if (isOrientationChanged) {
+            Log.i("ConfigCheck", "🟢 Orientation change detected → keep Unity engine (orientation=${newConfig.orientation})")
+            unityPlayer.configurationChanged(newConfig)
+        } else {
+            Log.w("ConfigCheck", "🔴 Non-orientation config change detected → restarting app (diff=$diff)")
+            restartApp()
+        }
+
+        lastConfig = Configuration(newConfig)
+    }
+
+    private fun restartApp() {
+        val intent = packageManager.getLaunchIntentForPackage(packageName) ?: return
+        // CLEAR_TASK: 기존 태스크 스택 전체 제거 후 새 태스크에서 재시작
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        startActivity(intent)
+        // 현재 태스크의 모든 Activity 종료 후 프로세스 종료
+        finishAffinity()
+        Runtime.getRuntime().exit(0)
     }
 }

--- a/feature/src/main/java/com/zcard/feature/MainActivity.kt
+++ b/feature/src/main/java/com/zcard/feature/MainActivity.kt
@@ -36,7 +36,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         layoutParams = binding.unityContainer.layoutParams as ConstraintLayout.LayoutParams
-        lastConfig = resources.configuration
+        lastConfig = Configuration(resources.configuration)
 
         setContentView(binding.root)
 
@@ -162,6 +162,11 @@ class MainActivity : AppCompatActivity() {
         super.onConfigurationChanged(newConfig)
 
         val diff = lastConfig?.diff(newConfig) ?: return
+        val intent = packageManager.getLaunchIntentForPackage(packageName)
+        if (intent == null) {
+            Log.e("ConfigCheck", "Failed to get launch intent for package: $packageName")
+            return
+        }
         val isOrientationChanged = (diff and ActivityInfo.CONFIG_ORIENTATION) != 0 || (diff and ActivityInfo.CONFIG_SCREEN_SIZE) != 0
 
         if (isOrientationChanged) {

--- a/libs/unityLibrary-release.aar
+++ b/libs/unityLibrary-release.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee697f9cd5babdd9fd882c685729b30af5a39bf34b25b99757ddb140f56bdac8
-size 82849522
+oid sha256:ae3b0a7f3f7e15dd05dc661dfefbc47d51cadf7732c56d4383507eb6e0ad47de
+size 103456009


### PR DESCRIPTION
## Related Issue
- Close: #125 
## Context
- #122 작업 과정에서 발견된 화면 회전 감지 로직의 파생 오류를 해결하기 위한 후속 PR입니다.
## Summary
- 문제점: Config Change에 따른 프로세스 종료
- 해결: Activity의 Config 변화에 대한 대응 커스텀
    - 화면 회전 별도로 처리 (UaaL 세로 고정 및 Config Changes 시 Activity 유지)
    - 그 외 Config 변화 시에는 `onConfigChanges()`에서 앱 Restart 트리거
    - 다크 모드, 글꼴 크기, 언어 변경은 앱 재시작이 필요하므로 화면 회전과 혼합 변경 상황 시 Critical Mask로 추가 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **앱 안정성 개선**
  * 화면 회전·화면 크기 변경 시 앱 동작을 더 원활하게 유지합니다.
  * 언어·UI 모드·글꼴 배율 등 다양한 시스템 설정 변경을 보다 안정적으로 처리합니다.
  * 특정 설정 변경에서는 앱을 안전하게 재시작해 상태를 정리하고 일관된 동작을 보장합니다.
  * 멀티태스킹 환경에서 기존 인스턴스를 보다 일관되게 재사용합니다.
* **수정/유지보수**
  * 내장 Unity 라이브러리 파일이 업데이트되어 바이너리가 변경되었습니다. (UaaL 앱 Orientation 세로 모드 고정)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->