### PR TITLE
[UI/#145] 카드 에디터 레이아웃 개선 및 Window Insets 적용 

### DIFF
--- a/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorFragment.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorFragment.kt
@@ -72,6 +72,24 @@ class CardEditorFragment : Fragment() {
         cardId = requireArguments().getLong(ARG_CARD_ID)    // newInstance로만 생성되므로 없으면 즉시 크래시
         viewModel.onIntent(CardEditorIntent.Init(cardId))
 
+        val initialTopPadding = binding.containerTop.paddingTop
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.containerTop) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.statusBars())
+            v.setPadding(0, initialTopPadding + insets.top, 0, 0)
+            windowInsets
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val imeVisible = windowInsets.isVisible(WindowInsetsCompat.Type.ime())
+            val navInsets = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
+
+            viewModel.setImeVisible(imeVisible)
+            v.setPadding(0, 0, 0, navInsets.bottom)
+
+            windowInsets
+        }
+
         initListener()
 
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
@@ -184,12 +202,6 @@ class CardEditorFragment : Fragment() {
 
         binding.imgBtnCameraFocusReset.setOnClickListener {
             viewModel.onIntent(CardEditorIntent.ResetCamera)
-        }
-
-        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
-            val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-            viewModel.setImeVisible(imeVisible)
-            insets
         }
     }
 

--- a/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorState.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorState.kt
@@ -47,7 +47,7 @@ data class CardEditorState(
         get() = panelType == PanelType.TEXT_EDITOR
 
     val unityContainerHeightFraction: Float
-        get() = if (panelType == PanelType.TRANSFORM_CONTROL || panelType == PanelType.TEXT_EDITOR) 0.6f else 0.5f
+        get() = if (panelType == PanelType.TRANSFORM_CONTROL || panelType == PanelType.TEXT_EDITOR) 0.6f else 0.52f
 
     val selectedSpawnedObjectId: Long?
         get() = selectedSpawnedObject?.cardElement?.elementId

--- a/feature/src/main/java/com/zcard/feature/cardeditor/ui/panels/AssetBrowserPanel.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/ui/panels/AssetBrowserPanel.kt
@@ -41,7 +41,7 @@ import com.zcard.feature.cardeditor.util.getObjectThumbByKey
 import com.zcard.designsystem.util.DrawableResProvider.getBgThumbByKey
 import com.zcard.feature.R
 
-private const val COLUMNS = 3
+private const val COLUMNS = 4
 
 // 토글 탭 목록 정의
 enum class AssetBrowserTab(val resId: Int) {
@@ -180,21 +180,21 @@ fun SpawnedObjectRow(
 
     Column {
         Text(
-            modifier = Modifier.padding(horizontal = 20.dp).padding(bottom = 12.dp),
+            modifier = Modifier.padding(horizontal = 20.dp).padding(bottom = 10.dp),
             text = stringResource(R.string.editor_title_spawned_objects_list),
             style = MaterialTheme.typography.labelSmall,
             fontSize = 14.sp
         )
         LazyRow(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
-            contentPadding = PaddingValues(bottom = 24.dp)
+            contentPadding = PaddingValues(bottom = 18.dp)
         ) {
             item { Box(Modifier.size(8.dp)) }
             items(items = elements, key = { it.cardElement.elementId }) { element ->
                 val isLoading = isLoading(element.cardElement.elementId)
                 Box(
                     modifier = Modifier
-                        .size(72.dp)
+                        .size(60.dp)
                         .border(
                             2.dp,
                             if (element.cardElement.elementId == selectedItemIndex) SoftBlack else Gray,

--- a/feature/src/main/java/com/zcard/feature/cardshare/CardShareScreen.kt
+++ b/feature/src/main/java/com/zcard/feature/cardshare/CardShareScreen.kt
@@ -39,7 +39,11 @@ private fun CardShareContent(
     onHomeClicked: () -> Unit = {},
     onShareClicked: () -> Unit = {}
 ) {
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .navigationBarsPadding()
+    ) {
 
         CardShareWebView(cardUrl)
 
@@ -54,8 +58,9 @@ private fun TopSection(onBackClicked: () -> Unit, onCompleteClicked: () -> Unit)
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp)
-            .padding(top = 30.dp),
+            .statusBarsPadding()
+            .padding(top = 10.dp)
+            .padding(horizontal = 20.dp),
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         BackButton(onBackClicked)

--- a/feature/src/main/res/layout/fragment_card_editor.xml
+++ b/feature/src/main/res/layout/fragment_card_editor.xml
@@ -11,7 +11,6 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_percent="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/feature/src/main/res/layout/fragment_card_editor.xml
+++ b/feature/src/main/res/layout/fragment_card_editor.xml
@@ -15,45 +15,53 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <ImageButton
-        android:id="@+id/img_btn_back"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:background="@drawable/bg_circle_white_70"
-        android:layout_marginTop="30dp"
-        android:layout_marginStart="20dp"
-        android:contentDescription="@string/common_cd_back_button"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:srcCompat="@drawable/ic_arrow_left" />
-
-    <ImageButton
-        android:id="@+id/img_btn_link"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:layout_marginEnd="12dp"
-        android:background="@drawable/bg_circle_white_70"
-        android:layout_marginTop="30dp"
-        android:layout_marginStart="20dp"
-        android:contentDescription="@string/editor_cd_link_button"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/btn_complete"
-        app:srcCompat="@drawable/ic_link" />
-
-    <android.widget.Button
-        android:id="@+id/btn_complete"
-        android:layout_width="wrap_content"
-        android:layout_height="48dp"
-        android:layout_marginTop="30dp"
-        android:layout_marginEnd="20dp"
-        android:paddingHorizontal="18dp"
-        android:background="@drawable/bg_rounded_rect_white_70"
-        android:contentDescription="@string/editor_cd_complete_button"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/container_top"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="10dp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:textColor="@color/soft_black"
-        android:textAllCaps="false"
-        android:text="@string/editor_button_complete" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageButton
+            android:id="@+id/img_btn_back"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="@drawable/bg_circle_white_70"
+            android:layout_marginStart="20dp"
+            android:contentDescription="@string/common_cd_back_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:srcCompat="@drawable/ic_arrow_left" />
+
+        <ImageButton
+            android:id="@+id/img_btn_link"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="12dp"
+            android:background="@drawable/bg_circle_white_70"
+            android:layout_marginStart="20dp"
+            android:contentDescription="@string/editor_cd_link_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/btn_complete"
+            app:srcCompat="@drawable/ic_link" />
+
+        <android.widget.Button
+            android:id="@+id/btn_complete"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:layout_marginEnd="20dp"
+            android:paddingHorizontal="18dp"
+            android:background="@drawable/bg_rounded_rect_white_70"
+            android:contentDescription="@string/editor_cd_complete_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:textColor="@color/soft_black"
+            android:textAllCaps="false"
+            android:text="@string/editor_button_complete" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/container_text_option"


### PR DESCRIPTION
## Related Issue
- Close: #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **UI 개선**
  * 에셋 브라우저 그리드 레이아웃을 3열에서 4열로 변경하여 더 많은 콘텐츠 표시
  * 화면 상단 및 하단 안전 영역 패딩 처리 개선
  * 카드 편집 및 공유 화면의 컨테이너 높이 비율 및 버튼 배치 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrj022/z-card/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->