### PR TITLE
[Feat/#158] 카드 편집기 버튼 라벨/다이얼로그 UI 개선 및 공유 화면 연결 

### DIFF
--- a/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorIntent.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorIntent.kt
@@ -12,7 +12,7 @@ sealed class CardEditorIntent {
 
     data object OpenCardLinkDetail: CardEditorIntent()
     data object SaveTitle: CardEditorIntent()
-    data object CopyCardLink: CardEditorIntent()
+    data object NavigateToCardShare: CardEditorIntent()
     data object ResetTitle: CardEditorIntent()
 
     data object FinishEditing: CardEditorIntent()

--- a/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorScreen.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorScreen.kt
@@ -87,7 +87,7 @@ fun CardEditorScreen(viewModel: CardEditorViewModel = hiltViewModel()) {
                 isTitleChanged = state.isTitleChanged,
                 onTitleChange = { viewModel.onIntent(CardEditorIntent.ChangeTitle(it)) },
                 onTitleSave = { viewModel.onIntent(CardEditorIntent.SaveTitle) },
-                onViewLink = { viewModel.onIntent(CardEditorIntent.CopyCardLink) },
+                onViewLink = { viewModel.onIntent(CardEditorIntent.NavigateToCardShare) },
                 onDismiss = {
                     viewModel.onIntent(CardEditorIntent.ResetTitle)
                     viewModel.onIntent(CardEditorIntent.ChangeDialogState(CardEditorState.DialogState.NONE))

--- a/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorScreen.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorScreen.kt
@@ -87,7 +87,7 @@ fun CardEditorScreen(viewModel: CardEditorViewModel = hiltViewModel()) {
                 isTitleChanged = state.isTitleChanged,
                 onTitleChange = { viewModel.onIntent(CardEditorIntent.ChangeTitle(it)) },
                 onTitleSave = { viewModel.onIntent(CardEditorIntent.SaveTitle) },
-                onCopyLink = { viewModel.onIntent(CardEditorIntent.CopyCardLink) },
+                onViewLink = { viewModel.onIntent(CardEditorIntent.CopyCardLink) },
                 onDismiss = {
                     viewModel.onIntent(CardEditorIntent.ResetTitle)
                     viewModel.onIntent(CardEditorIntent.ChangeDialogState(CardEditorState.DialogState.NONE))

--- a/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorViewModel.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorViewModel.kt
@@ -70,7 +70,7 @@ class CardEditorViewModel @Inject constructor(
             is CardEditorIntent.OpenCardLinkDetail -> handleOpenCardLinkDetail()
             is CardEditorIntent.SaveTitle -> handleSaveTitle()
             is CardEditorIntent.ResetTitle -> handleResetTitle()
-            is CardEditorIntent.CopyCardLink -> handleCopyCardLink()
+            is CardEditorIntent.NavigateToCardShare -> handleNavigateToCardShare()
 
             is CardEditorIntent.FinishEditing -> handleFinishEditing()
             is CardEditorIntent.ExportGlbAndUpload -> handleExportGlbAndUpload()
@@ -236,9 +236,11 @@ class CardEditorViewModel @Inject constructor(
         updateDialogState(CardEditorState.DialogState.CARD_LINK_DETAIL)
     }
 
-    private fun handleCopyCardLink() {
+    private fun handleNavigateToCardShare() {
         viewModelScope.launch {
-            _cardEditorSideEffect.trySend(CardEditorSideEffect.CopyCardLink(_cardEditorState.value.cardUrl))
+            val cardUrl = generateCardUrlUseCase(cardId).getOrThrow()
+            _cardEditorState.update { it.copy(dialogState = CardEditorState.DialogState.NONE) }
+            _cardEditorSideEffect.trySend(CardEditorSideEffect.NavigateToCardShare(cardUrl))
         }
     }
 

--- a/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorViewModel.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/CardEditorViewModel.kt
@@ -238,9 +238,14 @@ class CardEditorViewModel @Inject constructor(
 
     private fun handleNavigateToCardShare() {
         viewModelScope.launch {
-            val cardUrl = generateCardUrlUseCase(cardId).getOrThrow()
-            _cardEditorState.update { it.copy(dialogState = CardEditorState.DialogState.NONE) }
-            _cardEditorSideEffect.trySend(CardEditorSideEffect.NavigateToCardShare(cardUrl))
+            generateCardUrlUseCase(cardId)
+                .onSuccess { cardUrl ->
+                    _cardEditorState.update { it.copy(dialogState = CardEditorState.DialogState.NONE) }
+                    _cardEditorSideEffect.trySend(CardEditorSideEffect.NavigateToCardShare(cardUrl))
+                }.onFailure {
+                    Log.e(TAG, "handleNavigateToCardShare: $it")
+                    _cardEditorSideEffect.trySend(CardEditorSideEffect.ToastMessage(R.string.editor_msg_fail_generate_link))
+                }
         }
     }
 

--- a/feature/src/main/java/com/zcard/feature/cardeditor/dialog/CardInfoDialog.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/dialog/CardInfoDialog.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -87,6 +88,7 @@ fun CardInfoDialog(
             }
             Row(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .padding(top = 10.dp)
                     .clickable { onViewLink() }
                     .padding(10.dp),

--- a/feature/src/main/java/com/zcard/feature/cardeditor/dialog/CardInfoDialog.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/dialog/CardInfoDialog.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -24,8 +25,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.zcard.feature.R
 import com.zcard.designsystem.component.BaseDialog
+import com.zcard.designsystem.theme.DimGray
 import com.zcard.designsystem.theme.Gray
 import com.zcard.designsystem.theme.White
 
@@ -35,7 +38,7 @@ fun CardInfoDialog(
     isTitleChanged: Boolean = false,
     onTitleChange: (String) -> Unit,
     onTitleSave: () -> Unit,
-    onCopyLink: () -> Unit,
+    onViewLink: () -> Unit,
     onDismiss: () -> Unit
 ) {
     BaseDialog(
@@ -83,31 +86,28 @@ fun CardInfoDialog(
                 }
             }
             Row(
-                modifier = Modifier.padding(top = 10.dp),
+                modifier = Modifier
+                    .padding(top = 10.dp)
+                    .clickable { onViewLink() }
+                    .padding(10.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                Row(
-                    modifier = Modifier
-                        .clickable { onCopyLink() }
-                        .padding(10.dp),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_copy),
-                        contentDescription = null,
-                        modifier = Modifier.size(14.dp),
-                    )
-                    Text(
-                        text = stringResource(R.string.editor_dialog_button_link_copy),
-                        style = MaterialTheme.typography.labelSmall,
-                    )
-                }
+                Icon(
+                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_link),
+                    contentDescription = null,
+                    modifier = Modifier.size(14.dp),
+                )
+                Spacer(modifier = Modifier.size(10.dp))
+                Text(
+                    text = stringResource(R.string.editor_dialog_button_view_link),
+                    style = MaterialTheme.typography.labelSmall,
+                )
+                Spacer(modifier = Modifier.size(10.dp))
                 Text(
                     text = stringResource(R.string.editor_dialog_text_exclude_new_edit),
                     style = MaterialTheme.typography.labelSmall,
-                    color = Gray
+                    fontSize = 9.sp,
+                    color = DimGray
                 )
             }
         }
@@ -121,6 +121,6 @@ private fun CardInfoDialogPreview() {
         onTitleChange = {},
         onTitleSave = {},
         onDismiss = {},
-        onCopyLink = {}
+        onViewLink = {}
     )
 }

--- a/feature/src/main/java/com/zcard/feature/cardeditor/textedit/TextEditScreen.kt
+++ b/feature/src/main/java/com/zcard/feature/cardeditor/textedit/TextEditScreen.kt
@@ -185,7 +185,7 @@ private fun EditorHeader(
                     tint = SoftBlack
                 )
                 Text(
-                    text = stringResource(R.string.common_cd_back_button),
+                    text = stringResource(R.string.text_edit_button_back),
                     style = MaterialTheme.typography.labelSmall,
                     color = SoftBlack
                 )

--- a/feature/src/main/res/values-de/strings.xml
+++ b/feature/src/main/res/values-de/strings.xml
@@ -21,7 +21,7 @@
     <string name="editor_loading_msg_uploading">Upload %1$d%%</string>
 
     <string name="editor_button_adjust">Anpassen</string>
-    <string name="editor_button_complete">Fertig</string>
+    <string name="editor_button_complete">Generieren</string>
     <string name="editor_button_add_text">Text bearbeiten</string>
 
     <string name="editor_title_asset_tab_objects">3D-Objekt</string>
@@ -61,6 +61,7 @@
     <string name="editor_dialog_text_exclude_new_edit">Neue Bearbeitungen ausgeschlossen</string>
 
     <!-- Text Edit Screen -->
+    <string name="text_edit_button_back">Zurück</string>
     <string name="text_edit_msg_fail_load">Texte konnten nicht geladen werden.</string>
     <string name="text_edit_msg_fail_save">Speichern fehlgeschlagen. Bitte erneut versuchen.</string>
     <string name="text_edit_msg_partial_fail_save">Einige Änderungen konnten nicht gespeichert werden.</string>

--- a/feature/src/main/res/values-de/strings.xml
+++ b/feature/src/main/res/values-de/strings.xml
@@ -17,6 +17,7 @@
     <string name="editor_msg_copy_success">In die Zwischenablage kopiert</string>
     <string name="editor_msg_cancel_card_upload">Karten-Upload abgebrochen</string>
     <string name="editor_msg_block_back_during_export">Export läuft. Bitte warte einen Moment.</string>
+    <string name="editor_msg_fail_generate_link">Link konnte nicht erstellt werden. Bitte erneut versuchen.</string>
     <string name="editor_loading_msg_network_required">Diese Aufgabe erfordert eine Netzwerkverbindung.</string>
     <string name="editor_loading_msg_uploading">Upload %1$d%%</string>
 

--- a/feature/src/main/res/values-de/strings.xml
+++ b/feature/src/main/res/values-de/strings.xml
@@ -57,8 +57,8 @@
     <!-- Editor Screen - Dialog (Link Detail) -->
     <string name="editor_dialog_title_link_detail">Karten-Link kopieren</string>
     <string name="editor_dialog_button_set_card_title_save">Speichern</string>
-    <string name="editor_dialog_button_link_copy">Link kopieren</string>
-    <string name="editor_dialog_text_exclude_new_edit">Neue Bearbeitungen ausgeschlossen</string>
+    <string name="editor_dialog_button_view_link">Link ansehen</string>
+    <string name="editor_dialog_text_exclude_new_edit">Neue Änderungen sind nicht enthalten</string>
 
     <!-- Text Edit Screen -->
     <string name="text_edit_button_back">Zurück</string>

--- a/feature/src/main/res/values-de/strings.xml
+++ b/feature/src/main/res/values-de/strings.xml
@@ -55,7 +55,7 @@
     <string name="editor_dialog_content_cancel_upload">Upload abbrechen?</string>
 
     <!-- Editor Screen - Dialog (Link Detail) -->
-    <string name="editor_dialog_title_link_detail">Karten-Link kopieren</string>
+    <string name="editor_dialog_title_link_detail">Kartendetails</string>
     <string name="editor_dialog_button_set_card_title_save">Speichern</string>
     <string name="editor_dialog_button_view_link">Link ansehen</string>
     <string name="editor_dialog_text_exclude_new_edit">Neue Änderungen sind nicht enthalten</string>

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -17,6 +17,7 @@
     <string name="editor_msg_copy_success">Copiado al portapapeles</string>
     <string name="editor_msg_cancel_card_upload">Subida de tarjeta cancelada</string>
     <string name="editor_msg_block_back_during_export">Exportación en curso. Por favor, espera un momento.</string>
+    <string name="editor_msg_fail_generate_link">No se pudo generar el enlace. Por favor, inténtalo de nuevo.</string>
     <string name="editor_loading_msg_network_required">Esta tarea requiere conexión a internet.</string>
     <string name="editor_loading_msg_uploading">Subiendo %1$d%%</string>
 

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -57,8 +57,8 @@
     <!-- Editor Screen - Dialog (Link Detail) -->
     <string name="editor_dialog_title_link_detail">Copiar enlace de tarjeta</string>
     <string name="editor_dialog_button_set_card_title_save">Guardar</string>
-    <string name="editor_dialog_button_link_copy">Copiar enlace</string>
-    <string name="editor_dialog_text_exclude_new_edit">Excluye nuevas ediciones</string>
+    <string name="editor_dialog_button_view_link">Ver enlace</string>
+    <string name="editor_dialog_text_exclude_new_edit">Las ediciones nuevas no están incluidas</string>
 
     <!-- Text Edit Screen -->
     <string name="text_edit_button_back">Volver</string>

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -21,7 +21,7 @@
     <string name="editor_loading_msg_uploading">Subiendo %1$d%%</string>
 
     <string name="editor_button_adjust">Ajustar</string>
-    <string name="editor_button_complete">Listo</string>
+    <string name="editor_button_complete">Generar</string>
     <string name="editor_button_add_text">Editar texto</string>
 
     <string name="editor_title_asset_tab_objects">Objeto 3D</string>
@@ -61,6 +61,7 @@
     <string name="editor_dialog_text_exclude_new_edit">Excluye nuevas ediciones</string>
 
     <!-- Text Edit Screen -->
+    <string name="text_edit_button_back">Volver</string>
     <string name="text_edit_msg_fail_load">No se pudieron cargar los textos.</string>
     <string name="text_edit_msg_fail_save">Error al guardar. Por favor, inténtalo de nuevo.</string>
     <string name="text_edit_msg_partial_fail_save">Algunos cambios no se pudieron guardar.</string>

--- a/feature/src/main/res/values-es/strings.xml
+++ b/feature/src/main/res/values-es/strings.xml
@@ -55,7 +55,7 @@
     <string name="editor_dialog_content_cancel_upload">¿Quieres cancelar la subida?</string>
 
     <!-- Editor Screen - Dialog (Link Detail) -->
-    <string name="editor_dialog_title_link_detail">Copiar enlace de tarjeta</string>
+    <string name="editor_dialog_title_link_detail">Detalle de tarjeta</string>
     <string name="editor_dialog_button_set_card_title_save">Guardar</string>
     <string name="editor_dialog_button_view_link">Ver enlace</string>
     <string name="editor_dialog_text_exclude_new_edit">Las ediciones nuevas no están incluidas</string>

--- a/feature/src/main/res/values-ja/strings.xml
+++ b/feature/src/main/res/values-ja/strings.xml
@@ -57,8 +57,8 @@
     <!-- Editor Screen - Dialog (Link Detail) -->
     <string name="editor_dialog_title_link_detail">カードリンクをコピー</string>
     <string name="editor_dialog_button_set_card_title_save">保存</string>
-    <string name="editor_dialog_button_link_copy">リンクをコピー</string>
-    <string name="editor_dialog_text_exclude_new_edit">新しい編集は含まれません</string>
+    <string name="editor_dialog_button_view_link">リンクを見る</string>
+    <string name="editor_dialog_text_exclude_new_edit">新しい編集内容は含まれません</string>
 
     <!-- Text Edit Screen -->
     <string name="text_edit_button_back">戻る</string>

--- a/feature/src/main/res/values-ja/strings.xml
+++ b/feature/src/main/res/values-ja/strings.xml
@@ -17,6 +17,7 @@
     <string name="editor_msg_copy_success">クリップボードにコピーしました</string>
     <string name="editor_msg_cancel_card_upload">カードのアップロードがキャンセルされました</string>
     <string name="editor_msg_block_back_during_export">エクスポート中はキャンセルできません。少々お待ちください。</string>
+    <string name="editor_msg_fail_generate_link">リンクの生成に失敗しました。もう一度お試しください。</string>
     <string name="editor_loading_msg_network_required">この作業にはネットワーク接続が必要です。</string>
     <string name="editor_loading_msg_uploading">%1$d%% アップロード中</string>
 

--- a/feature/src/main/res/values-ja/strings.xml
+++ b/feature/src/main/res/values-ja/strings.xml
@@ -21,7 +21,7 @@
     <string name="editor_loading_msg_uploading">%1$d%% アップロード中</string>
 
     <string name="editor_button_adjust">調整</string>
-    <string name="editor_button_complete">完了</string>
+    <string name="editor_button_complete">生成</string>
     <string name="editor_button_add_text">テキスト編集</string>
 
     <string name="editor_title_asset_tab_objects">3Dオブジェクト</string>
@@ -61,6 +61,7 @@
     <string name="editor_dialog_text_exclude_new_edit">新しい編集は含まれません</string>
 
     <!-- Text Edit Screen -->
+    <string name="text_edit_button_back">戻る</string>
     <string name="text_edit_msg_fail_load">テキストを読み込めませんでした。</string>
     <string name="text_edit_msg_fail_save">保存に失敗しました。もう一度お試しください。</string>
     <string name="text_edit_msg_partial_fail_save">一部の変更を保存できませんでした。</string>

--- a/feature/src/main/res/values-ja/strings.xml
+++ b/feature/src/main/res/values-ja/strings.xml
@@ -55,7 +55,7 @@
     <string name="editor_dialog_content_cancel_upload">アップロードをキャンセルしますか？</string>
 
     <!-- Editor Screen - Dialog (Link Detail) -->
-    <string name="editor_dialog_title_link_detail">カードリンクをコピー</string>
+    <string name="editor_dialog_title_link_detail">カード詳細</string>
     <string name="editor_dialog_button_set_card_title_save">保存</string>
     <string name="editor_dialog_button_view_link">リンクを見る</string>
     <string name="editor_dialog_text_exclude_new_edit">新しい編集内容は含まれません</string>

--- a/feature/src/main/res/values-ko/strings.xml
+++ b/feature/src/main/res/values-ko/strings.xml
@@ -57,8 +57,8 @@
     <!-- Editor Screen - Dialog (Link Detail) -->
     <string name="editor_dialog_title_link_detail">카드 정보</string>
     <string name="editor_dialog_button_set_card_title_save">저장</string>
-    <string name="editor_dialog_button_link_copy">링크 복사</string>
-    <string name="editor_dialog_text_exclude_new_edit">새 편집 내용 미포함</string>
+    <string name="editor_dialog_button_view_link">링크 보기</string>
+    <string name="editor_dialog_text_exclude_new_edit">새로운 편집 내용은 포함되지 않아요</string>
 
     <!-- Text Edit Screen -->
     <string name="text_edit_button_back">Back</string>

--- a/feature/src/main/res/values-ko/strings.xml
+++ b/feature/src/main/res/values-ko/strings.xml
@@ -17,6 +17,7 @@
     <string name="editor_msg_copy_success">클립보드에 복사됐어요</string>
     <string name="editor_msg_cancel_card_upload">카드 업로드가 취소됐어요</string>
     <string name="editor_msg_block_back_during_export">추출 중에는 취소할 수 없어요. 잠시만 기다려 주세요.</string>
+    <string name="editor_msg_fail_generate_link">링크 생성에 실패했어요. 다시 시도해 주세요.</string>
     <string name="editor_loading_msg_network_required">네트워크가 필요한 작업이에요.</string>
     <string name="editor_loading_msg_uploading">%1$d%% 업로드 중</string>
 

--- a/feature/src/main/res/values-ko/strings.xml
+++ b/feature/src/main/res/values-ko/strings.xml
@@ -1,11 +1,11 @@
 <resources>
     <!-- Common -->
-    <string name="common_cd_back_button">뒤로 가기</string>
+    <string name="common_cd_back_button">뒤로가기</string>
     <string name="common_button_cancel">취소</string>
     <string name="common_button_confirm">확인</string>
     <string name="common_button_yes">네</string>
     <string name="common_button_no">아니요</string>
-    <string name="common_button_apply">적용</string>
+    <string name="common_button_apply">저장</string>
 
     <!-- Editor Screen -->
     <string name="editor_msg_fail_load_card">카드를 불러오지 못했어요. 다시 시도해 주세요.</string>
@@ -21,7 +21,7 @@
     <string name="editor_loading_msg_uploading">%1$d%% 업로드 중</string>
 
     <string name="editor_button_adjust">Adjust</string>
-    <string name="editor_button_complete">Complete</string>
+    <string name="editor_button_complete">Generate</string>
     <string name="editor_button_add_text">Edit Text</string>
 
     <string name="editor_title_asset_tab_objects">3D Object</string>
@@ -61,6 +61,7 @@
     <string name="editor_dialog_text_exclude_new_edit">새 편집 내용 미포함</string>
 
     <!-- Text Edit Screen -->
+    <string name="text_edit_button_back">Back</string>
     <string name="text_edit_msg_fail_load">텍스트를 불러오지 못했어요.</string>
     <string name="text_edit_msg_fail_save">저장에 실패했어요. 다시 시도해 주세요.</string>
     <string name="text_edit_msg_partial_fail_save">일부 변경 사항을 저장하지 못했어요.</string>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -55,7 +55,7 @@
     <string name="editor_dialog_content_cancel_upload">Do you want to cancel the upload?</string>
 
     <!-- Editor Screen - Dialog (Link Detail) -->
-    <string name="editor_dialog_title_link_detail">Copy Card Link</string>
+    <string name="editor_dialog_title_link_detail">Card Detail</string>
     <string name="editor_dialog_button_set_card_title_save">Save</string>
     <string name="editor_dialog_button_view_link">View Link</string>
     <string name="editor_dialog_text_exclude_new_edit">New edits are not included</string>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -57,8 +57,8 @@
     <!-- Editor Screen - Dialog (Link Detail) -->
     <string name="editor_dialog_title_link_detail">Copy Card Link</string>
     <string name="editor_dialog_button_set_card_title_save">Save</string>
-    <string name="editor_dialog_button_link_copy">Copy Link</string>
-    <string name="editor_dialog_text_exclude_new_edit">Excludes new edits</string>
+    <string name="editor_dialog_button_view_link">View Link</string>
+    <string name="editor_dialog_text_exclude_new_edit">New edits are not included</string>
 
     <!-- Transform Screen -->
     <string name="transform_msg_fail_load_object">Failed to load object. Please try again.</string>

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="editor_msg_copy_success">Copied to clipboard</string>
     <string name="editor_msg_cancel_card_upload">Card upload cancelled</string>
     <string name="editor_msg_block_back_during_export">Export in progress. Please wait a moment.</string>
+    <string name="editor_msg_fail_generate_link">Failed to generate link. Please try again.</string>
     <string name="editor_loading_msg_network_required">This task requires a network connection.</string>
     <string name="editor_loading_msg_uploading">Uploading %1$d%%</string>
 

--- a/feature/src/main/res/values/strings.xml
+++ b/feature/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="editor_loading_msg_uploading">Uploading %1$d%%</string>
 
     <string name="editor_button_adjust">Adjust</string>
-    <string name="editor_button_complete">Complete</string>
+    <string name="editor_button_complete">Generate</string>
     <string name="editor_button_add_text">Edit Text</string>
 
     <string name="editor_title_asset_tab_objects">3D Object</string>
@@ -70,6 +70,7 @@
     <string name="transform_cd_decrease_scale">Decrease Scale</string>
 
     <!-- Text Edit Screen -->
+    <string name="text_edit_button_back">Back</string>
     <string name="text_edit_msg_fail_load">Failed to load texts.</string>
     <string name="text_edit_msg_fail_save">Failed to save. Please try again.</string>
     <string name="text_edit_msg_partial_fail_save">Some changes couldn\'t be saved.</string>


### PR DESCRIPTION
## Related Issue
- Close: #158 

## Changes
### 버튼 라벨 변경
- 카드 생성 버튼 라벨을 `Complete` → `Generate`로 변경
- 다국어(en/ko/ja/es/de) 리소스 반영                                                                                                                    

### 카드 정보 다이얼로그 UI 개선
- 링크 복사 버튼의 아이콘을 `ic_copy` → `ic_link`로 교체
- 버튼 라벨을 '링크 복사' → '링크 보기'로 변경
- 안내 텍스트 폰트 크기 9sp, 색상 `DimGray` 적용
- 불필요한 중첩 `Row` 제거 및 `Spacer`로 간격 조정
- 안내 문구(`editor_dialog_text_exclude_new_edit`)를 자연스러운 문장형으로 다국어 수정

### 공유 화면 연결
- `CopyCardLink` 인텐트를 `NavigateToCardShare`로 변경
- `generateCardUrlUseCase`로 URL 생성 후 공유 화면으로 이동하는 사이드 이펙트 처리
- 링크 생성 시 다이얼로그 상태 `NONE`으로 초기화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카드 링크 복사 동작이 제거되고 카드 공유 화면으로 이동하는 기능이 추가되었습니다.

* **개선 사항**
  * 완료 버튼 라벨이 "생성"으로 변경되었습니다.
  * 텍스트 편집 화면의 뒤로 가기 버튼 문구가 업데이트되었습니다.
  * 카드 링크 다이얼로그에서 "링크 복사"가 "링크 보기"로 변경되고 관련 안내 문구가 정리되었습니다.
  * 링크 생성 실패 메시지가 추가되어 오류 안내가 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrj022/z-card/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->